### PR TITLE
Support XDG Base Directory environment variables

### DIFF
--- a/src/bw.ts
+++ b/src/bw.ts
@@ -70,6 +70,8 @@ export class Main {
             p = path.join(process.env.HOME, 'Library/Application Support/Bitwarden CLI');
         } else if (process.platform === 'win32') {
             p = path.join(process.env.APPDATA, 'Bitwarden CLI');
+        } else if (process.env.XDG_CONFIG_HOME) {
+            p = path.join(process.env.XDG_CONFIG_HOME, 'Bitwarden CLI');
         } else {
             p = path.join(process.env.HOME, '.config/Bitwarden CLI');
         }


### PR DESCRIPTION
If the user sets `XDG_CONFIG_HOME` then the cli should respect that over the hardcoded `.config` path.