### PR TITLE
Add option to export vault data to stdout

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -503,6 +503,7 @@ export class Program extends BaseProgram {
             .option('--output <output>', 'Output directory or filename.')
             .option('--format <format>', 'Export file format.')
             .option('--organizationid <organizationid>', 'Organization id for an organization.')
+            .option('--to-stdout', 'Output result to stdout instead of writing to a file')
             .on('--help', () => {
                 writeLn('\n  Notes:');
                 writeLn('');


### PR DESCRIPTION
When using CLI tools it's often handy to be able to use stdout instead
of writing to a file.
Added an option `--to-stdout` when using the `export` command which
will output the export result to stdout rather than write to a file.

Tested by building the package and running:
`node bw.js export --to-stdout --format json`