### PR TITLE
fixing checksum file encoding to prevent encoding errors on linux

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -93,11 +93,11 @@ build_script:
     if($isWindows) {
       .\scripts\choco-pack.ps1
       checksum -f="./dist/bw-windows-${env:PACKAGE_VERSION}.zip" `
-        -t sha256 | Out-File ./dist/bw-windows-sha256-${env:PACKAGE_VERSION}.txt
+        -t sha256 | Out-File -Encoding ASCII ./dist/bw-windows-sha256-${env:PACKAGE_VERSION}.txt
       checksum -f="./dist/bw-macos-${env:PACKAGE_VERSION}.zip" `
-        -t sha256 | Out-File ./dist/bw-macos-sha256-${env:PACKAGE_VERSION}.txt
+        -t sha256 | Out-File -Encoding ASCII ./dist/bw-macos-sha256-${env:PACKAGE_VERSION}.txt
       checksum -f="./dist/bw-linux-${env:PACKAGE_VERSION}.zip" `
-        -t sha256 | Out-File ./dist/bw-linux-sha256-${env:PACKAGE_VERSION}.txt
+        -t sha256 | Out-File -Encoding ASCII ./dist/bw-linux-sha256-${env:PACKAGE_VERSION}.txt
 
       if($env:PROD_DEPLOY -ne "true") {
         Push-AppveyorArtifact .\dist\bw-windows-${env:PACKAGE_VERSION}.zip


### PR DESCRIPTION
There is a issue with the checksum fileencoding which i discovered because i wanted to verify the checksum on linux.
Here you can see that there are some encoding errors.
```bash
$ cat bw-Linux-sha256-1.9.1.txt
��5FE1AFDE45983D96F59BF1398A966CEDB48EFD0E2C81F58F63ABB01C422676FA
```

The fix is to use the Encoding parameter in Out-files powershell cmdlet.

**Proof:**
_Windows_
```powershell
PS > checksum -f="./bw-linux-1.9.1.zip" -t sha256 | Out-File -Encoding ASCII tmp.txt
PS > $checksum=Get-Content -Path .\tmp.txt
PS > checksum -f="./bw-linux-1.9.1.zip" -t sha256 -c "$checksum"
Hashes match.
````
_Linux_
```bash
$ cat tmp.txt
5FE1AFDE45983D96F59BF1398A966CEDB48EFD0E2C81F58F63ABB01C422676FA
```