### PR TITLE
[Soft Delete] Added --trash to delete cmd, added restore cmd

### DIFF
--- a/src/bw.ts
+++ b/src/bw.ts
@@ -116,9 +116,9 @@ export class Main {
             this.i18nService);
         this.searchService = new SearchService(this.cipherService, this.platformUtilsService);
         this.policyService = new PolicyService(this.userService, this.storageService);
-        this.vaultTimeoutService = new VaultTimeoutService(this.cipherService, this.folderService, this.collectionService,
-            this.cryptoService, this.platformUtilsService, this.storageService, this.messagingService,
-            this.searchService, this.userService, this.tokenService, null, null);
+        this.vaultTimeoutService = new VaultTimeoutService(this.cipherService, this.folderService,
+            this.collectionService, this.cryptoService, this.platformUtilsService, this.storageService,
+            this.messagingService, this.searchService, this.userService, this.tokenService, null, null);
         this.syncService = new SyncService(this.userService, this.apiService, this.settingsService,
             this.folderService, this.cipherService, this.cryptoService, this.collectionService,
             this.storageService, this.messagingService, this.policyService,

--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -13,15 +13,16 @@ export class ConfigCommand {
         setting = setting.toLowerCase();
         switch (setting) {
             case 'server':
-                return await this.getOrSetServer(value);
+                return await this.getOrSetServer(value, cmd);
             default:
                 return Response.badRequest('Unknown setting.');
         }
 
     }
 
-    private async getOrSetServer(url: string): Promise<Response> {
-        if (url == null || url.trim() === '') {
+    private async getOrSetServer(url: string, cmd: program.Command): Promise<Response> {
+        if ((url == null || url.trim() === '') &&
+            !cmd.webVault && !cmd.api && !cmd.identity && !cmd.icons && !cmd.notifications && !cmd.events) {
             const baseUrl = this.environmentService.baseUrl;
             const stringRes = new StringResponse(baseUrl == null ? 'https://bitwarden.com' : baseUrl);
             return Response.success(stringRes);
@@ -30,6 +31,12 @@ export class ConfigCommand {
         url = (url === 'null' || url === 'bitwarden.com' || url === 'https://bitwarden.com' ? null : url);
         await this.environmentService.setUrls({
             base: url,
+            webVault: cmd.webVault || null,
+            api: cmd.api || null,
+            identity: cmd.identity || null,
+            icons: cmd.icons || null,
+            notifications: cmd.notifications || null,
+            events: cmd.events || null,
         });
         const res = new MessageResponse('Saved setting `config`.', null);
         return Response.success(res);

--- a/src/commands/delete.command.ts
+++ b/src/commands/delete.command.ts
@@ -20,7 +20,7 @@ export class DeleteCommand {
 
         switch (object.toLowerCase()) {
             case 'item':
-                return await this.deleteCipher(id);
+                return await this.deleteCipher(id, cmd);
             case 'attachment':
                 return await this.deleteAttachment(id, cmd);
             case 'folder':
@@ -32,14 +32,18 @@ export class DeleteCommand {
         }
     }
 
-    private async deleteCipher(id: string) {
+    private async deleteCipher(id: string, cmd: program.Command) {
         const cipher = await this.cipherService.get(id);
         if (cipher == null) {
             return Response.notFound();
         }
 
         try {
-            await this.cipherService.deleteWithServer(id);
+            if (cmd.trash) {
+                await this.cipherService.softDeleteWithServer(id);
+            } else {
+                await this.cipherService.deleteWithServer(id);
+            }
             return Response.success();
         } catch (e) {
             return Response.error(e);

--- a/src/commands/delete.command.ts
+++ b/src/commands/delete.command.ts
@@ -39,10 +39,10 @@ export class DeleteCommand {
         }
 
         try {
-            if (cmd.trash) {
-                await this.cipherService.softDeleteWithServer(id);
-            } else {
+            if (cmd.permanent) {
                 await this.cipherService.deleteWithServer(id);
+            } else {
+                await this.cipherService.softDeleteWithServer(id);
             }
             return Response.success();
         } catch (e) {

--- a/src/commands/edit.command.ts
+++ b/src/commands/edit.command.ts
@@ -70,6 +70,9 @@ export class EditCommand {
         }
 
         let cipherView = await cipher.decrypt();
+        if (cipherView.isDeleted) {
+            return Response.badRequest('You may not edit a deleted cipher. Use restore item <id> command first.');
+        }
         cipherView = Cipher.toView(req, cipherView);
         const encCipher = await this.cipherService.encrypt(cipherView);
         try {

--- a/src/commands/list.command.ts
+++ b/src/commands/list.command.ts
@@ -66,6 +66,9 @@ export class ListCommand {
 
         if (cmd.folderid != null || cmd.collectionid != null || cmd.organizationid != null) {
             ciphers = ciphers.filter((c) => {
+                if (cmd.trash && !c.isDeleted) {
+                    return false;
+                }
                 if (cmd.folderid != null) {
                     if (cmd.folderid === 'notnull' && c.folderId != null) {
                         return true;
@@ -100,10 +103,12 @@ export class ListCommand {
                 }
                 return false;
             });
+        } else if (cmd.search == null || cmd.search.trim() === '') {
+            ciphers = ciphers.filter((c) => (cmd.trash || false) === c.isDeleted);
         }
 
         if (cmd.search != null && cmd.search.trim() !== '') {
-            ciphers = this.searchService.searchCiphersBasic(ciphers, cmd.search);
+            ciphers = this.searchService.searchCiphersBasic(ciphers, cmd.search, cmd.trash || false);
         }
 
         const res = new ListResponse(ciphers.map((o) => new CipherResponse(o)));

--- a/src/commands/list.command.ts
+++ b/src/commands/list.command.ts
@@ -58,6 +58,7 @@ export class ListCommand {
 
     private async listCiphers(cmd: program.Command) {
         let ciphers: CipherView[];
+        cmd.trash = cmd.trash || false;
         if (cmd.url != null && cmd.url.trim() !== '') {
             ciphers = await this.cipherService.getAllDecryptedForUrl(cmd.url);
         } else {
@@ -66,7 +67,7 @@ export class ListCommand {
 
         if (cmd.folderid != null || cmd.collectionid != null || cmd.organizationid != null) {
             ciphers = ciphers.filter((c) => {
-                if (cmd.trash && !c.isDeleted) {
+                if (cmd.trash !== c.isDeleted) {
                     return false;
                 }
                 if (cmd.folderid != null) {
@@ -104,11 +105,11 @@ export class ListCommand {
                 return false;
             });
         } else if (cmd.search == null || cmd.search.trim() === '') {
-            ciphers = ciphers.filter((c) => (cmd.trash || false) === c.isDeleted);
+            ciphers = ciphers.filter((c) => cmd.trash === c.isDeleted);
         }
 
         if (cmd.search != null && cmd.search.trim() !== '') {
-            ciphers = this.searchService.searchCiphersBasic(ciphers, cmd.search, cmd.trash || false);
+            ciphers = this.searchService.searchCiphersBasic(ciphers, cmd.search, cmd.trash);
         }
 
         const res = new ListResponse(ciphers.map((o) => new CipherResponse(o)));

--- a/src/commands/restore.command.ts
+++ b/src/commands/restore.command.ts
@@ -1,0 +1,39 @@
+import * as program from 'commander';
+
+import { CipherService } from 'jslib/abstractions/cipher.service';
+
+import { Response } from 'jslib/cli/models/response';
+
+export class RestoreCommand {
+    constructor(private cipherService: CipherService) { }
+
+    async run(object: string, id: string, cmd: program.Command): Promise<Response> {
+        if (id != null) {
+            id = id.toLowerCase();
+        }
+
+        switch (object.toLowerCase()) {
+            case 'item':
+                return await this.restoreCipher(id, cmd);
+            default:
+                return Response.badRequest('Unknown object.');
+        }
+    }
+
+    private async restoreCipher(id: string, cmd: program.Command) {
+        const cipher = await this.cipherService.get(id);
+        if (cipher == null) {
+            return Response.notFound();
+        }
+        if (cipher.deletedDate == null) {
+            return Response.badRequest('Cipher is not in trash.');
+        }
+
+        try {
+            await this.cipherService.restoreWithServer(id);
+            return Response.success();
+        } catch (e) {
+            return Response.error(e);
+        }
+    }
+}

--- a/src/program.ts
+++ b/src/program.ts
@@ -16,6 +16,7 @@ import { ImportCommand } from './commands/import.command';
 import { ListCommand } from './commands/list.command';
 import { LockCommand } from './commands/lock.command';
 import { LoginCommand } from './commands/login.command';
+import { RestoreCommand } from './commands/restore.command';
 import { ShareCommand } from './commands/share.command';
 import { SyncCommand } from './commands/sync.command';
 import { UnlockCommand } from './commands/unlock.command';
@@ -231,6 +232,7 @@ export class Program extends BaseProgram {
             .option('--folderid <folderid>', 'Filter items by folder id.')
             .option('--collectionid <collectionid>', 'Filter items by collection id.')
             .option('--organizationid <organizationid>', 'Filter items or collections by organization id.')
+            .option('--trash', 'Filter items that are deleted and in the trash.')
             .on('--help', () => {
                 writeLn('\n  Objects:');
                 writeLn('');
@@ -256,6 +258,7 @@ export class Program extends BaseProgram {
                 writeLn('    bw list items --folderid null');
                 writeLn('    bw list items --organizationid notnull');
                 writeLn('    bw list items --folderid 60556c31-e649-4b5d-8daf-fc1c391a1bf2 --organizationid notnull');
+                writeLn('    bw list items --trash');
                 writeLn('    bw list folders --search email');
                 writeLn('    bw list org-members --organizationid 60556c31-e649-4b5d-8daf-fc1c391a1bf2');
                 writeLn('', true);
@@ -393,6 +396,7 @@ export class Program extends BaseProgram {
             .command('delete <object> <id>')
             .option('--itemid <itemid>', 'Attachment\'s item id.')
             .option('--organizationid <organizationid>', 'Organization id for an organization object.')
+            .option('-t, --trash', 'Places the item in the trash instead of permanently deleting it (item only).')
             .description('Delete an object from the vault.')
             .on('--help', () => {
                 writeLn('\n  Objects:');
@@ -409,6 +413,7 @@ export class Program extends BaseProgram {
                 writeLn('  Examples:');
                 writeLn('');
                 writeLn('    bw delete item 7063feab-4b10-472e-b64c-785e2b870b92');
+                writeLn('    bw delete item 89c21cd2-fab0-4f69-8c6e-ab8a0168f69a --trash');
                 writeLn('    bw delete folder 5cdfbd80-d99f-409b-915b-f4c5d0241b02');
                 writeLn('    bw delete attachment b857igwl1dzrs2 --itemid 310d5ffd-e9a2-4451-af87-ea054dce0f78');
                 writeLn('', true);
@@ -417,6 +422,30 @@ export class Program extends BaseProgram {
                 await this.exitIfLocked();
                 const command = new DeleteCommand(this.main.cipherService, this.main.folderService,
                     this.main.userService, this.main.apiService);
+                const response = await command.run(object, id, cmd);
+                this.processResponse(response);
+            });
+
+        program
+            .command('restore <object> <id>')
+            .description('Restores an object from the trash.')
+            .on('--help', () => {
+                writeLn('\n  Objects:');
+                writeLn('');
+                writeLn('    item');
+                writeLn('');
+                writeLn('  Id:');
+                writeLn('');
+                writeLn('    Object\'s globally unique `id`.');
+                writeLn('');
+                writeLn('  Examples:');
+                writeLn('');
+                writeLn('    bw restore item 7063feab-4b10-472e-b64c-785e2b870b92');
+                writeLn('', true);
+            })
+            .action(async (object, id, cmd) => {
+                await this.exitIfLocked();
+                const command = new RestoreCommand(this.main.cipherService);
                 const response = await command.run(object, id, cmd);
                 this.processResponse(response);
             });
@@ -583,6 +612,12 @@ export class Program extends BaseProgram {
         program
             .command('config <setting> [value]')
             .description('Configure CLI settings.')
+            .option('--web-vault <url>', 'Provides a custom web vault URL that differs from the base URL.')
+            .option('--api <url>', 'Provides a custom API URL that differs from the base URL.')
+            .option('--identity <url>', 'Provides a custom identity URL that differs from the base URL.')
+            .option('--icons <url>', 'Provides a custom icons service URL that differs from the base URL.')
+            .option('--notifications <url>', 'Provides a custom notifications URL that differs from the base URL.')
+            .option('--events <url>', 'Provides a custom events URL that differs from the base URL.')
             .on('--help', () => {
                 writeLn('\n  Settings:');
                 writeLn('');
@@ -593,6 +628,7 @@ export class Program extends BaseProgram {
                 writeLn('    bw config server');
                 writeLn('    bw config server https://bw.company.com');
                 writeLn('    bw config server bitwarden.com');
+                writeLn('    bw config server --api http://localhost:4000 --identity http://localhost:33656');
                 writeLn('', true);
             })
             .action(async (setting, value, cmd) => {

--- a/src/program.ts
+++ b/src/program.ts
@@ -396,7 +396,7 @@ export class Program extends BaseProgram {
             .command('delete <object> <id>')
             .option('--itemid <itemid>', 'Attachment\'s item id.')
             .option('--organizationid <organizationid>', 'Organization id for an organization object.')
-            .option('-t, --trash', 'Places the item in the trash instead of permanently deleting it (item only).')
+            .option('-p, --permanent', 'Permanently deletes the item instead of soft-deleting it (item only).')
             .description('Delete an object from the vault.')
             .on('--help', () => {
                 writeLn('\n  Objects:');
@@ -413,7 +413,7 @@ export class Program extends BaseProgram {
                 writeLn('  Examples:');
                 writeLn('');
                 writeLn('    bw delete item 7063feab-4b10-472e-b64c-785e2b870b92');
-                writeLn('    bw delete item 89c21cd2-fab0-4f69-8c6e-ab8a0168f69a --trash');
+                writeLn('    bw delete item 89c21cd2-fab0-4f69-8c6e-ab8a0168f69a --permanent');
                 writeLn('    bw delete folder 5cdfbd80-d99f-409b-915b-f4c5d0241b02');
                 writeLn('    bw delete attachment b857igwl1dzrs2 --itemid 310d5ffd-e9a2-4451-af87-ea054dce0f78');
                 writeLn('', true);


### PR DESCRIPTION
## Overview
Added soft-delete, trash and restore operations to the CLI to ensure the CLI can participate in and perform all of the necessary functions supported by Bitwarden (functionally complete). Also updated the CLI's `config` option to be able to more granularly provide custom environment URLs similar to how other clients do (like desktop and browser extension).

## Updates
- **bw.ts**: lint error correction (line length)
- **config.command.ts**: handle individual environment URL settings with null fallback (default) since commander will leave properties `undefined` vs. `null` if not passed
- **delete.command.ts**: handle the `-t, --trash` flag when deleting an item to instead soft-delete that item (move to trash) vs. permanently deleting it. Only supports the Object type, _item_
- **edit.command.ts**: prevent editing a deleted item with an error message about the `restore item <id>` command which must be run first
- **list.command.ts**: like the other clients, deleted items are not included in search/list by default, only now with the `--trash` flag passed in will it search, list, etc. the trash bin for list operations against _item_ Object types. For all other Object types, the `--trash` flag is ignored _(should this return an error?)_
- **restore.command.ts**: new command type for restoring deleted items, staged to be consistent as delete, edit, etc. so other types could presumably be added in the future
- **program.ts**: options and help text generator configuration for commander added for the new command and command options, examples, etc.
