### PR TITLE
ability to manage groups via CLI

### DIFF
--- a/src/commands/delete.command.ts
+++ b/src/commands/delete.command.ts
@@ -27,6 +27,8 @@ export class DeleteCommand {
                 return await this.deleteFolder(id);
             case 'org-collection':
                 return await this.deleteOrganizationCollection(id, cmd);
+            case 'group':
+                return await this.deleteGroup(id, cmd);
             default:
                 return Response.badRequest('Unknown object.');
         }
@@ -104,6 +106,24 @@ export class DeleteCommand {
         }
         try {
             await this.apiService.deleteCollection(cmd.organizationid, id);
+            return Response.success();
+        } catch (e) {
+            return Response.error(e);
+        }
+    }
+
+    private async deleteGroup(id: string, cmd: program.Command) {
+        if (cmd.organizationid == null || cmd.organizationid === '') {
+            return Response.badRequest('--organizationid <organizationid> required.');
+        }
+        if (!Utils.isGuid(id)) {
+            return Response.error('`' + id + '` is not a GUID.');
+        }
+        if (!Utils.isGuid(cmd.organizationid)) {
+            return Response.error('`' + cmd.organizationid + '` is not a GUID.');
+        }
+        try {
+            await this.apiService.deleteGroup(cmd.organizationid, id);
             return Response.success();
         } catch (e) {
             return Response.error(e);

--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -38,6 +38,7 @@ import { StringResponse } from 'jslib/cli/models/response/stringResponse';
 import { CipherResponse } from '../models/response/cipherResponse';
 import { CollectionResponse } from '../models/response/collectionResponse';
 import { FolderResponse } from '../models/response/folderResponse';
+import { GroupDetailsResponse } from '../models/response/groupResponse';
 import { OrganizationCollectionResponse } from '../models/response/organizationCollectionResponse';
 import { OrganizationResponse } from '../models/response/organizationResponse';
 import { TemplateResponse } from '../models/response/templateResponse';
@@ -89,6 +90,8 @@ export class GetCommand {
                 return await this.getTemplate(id);
             case 'fingerprint':
                 return await this.getFingerprint(id);
+            case 'group':
+                return await this.getGroup(id, cmd);
             default:
                 return Response.badRequest('Unknown object.');
         }
@@ -458,5 +461,24 @@ export class GetCommand {
         }
         const res = new StringResponse(fingerprint.join('-'));
         return Response.success(res);
+    }
+
+    private async getGroup(id: string, cmd: program.Command) {
+        if (cmd.organizationid == null || cmd.organizationid === '') {
+            return Response.badRequest('--organizationid <organizationid> required.');
+        }
+        if (!Utils.isGuid(id)) {
+            return Response.error('`' + id + '` is not a GUID.');
+        }
+        if (!Utils.isGuid(cmd.organizationid)) {
+            return Response.error('`' + cmd.organizationid + '` is not a GUID.');
+        }
+        try {
+            const group = await this.apiService.getGroupDetails(cmd.organizationid, id);
+            const res = new GroupDetailsResponse(group);
+            return Response.success(res);
+        } catch (e) {
+            return Response.error(e);
+        }
     }
 }

--- a/src/models/response/groupResponse.ts
+++ b/src/models/response/groupResponse.ts
@@ -1,0 +1,32 @@
+import { BaseResponse } from 'jslib/cli/models/response/baseResponse';
+import {
+    GroupDetailsResponse as BaseGroupDetailsResponse,
+    GroupResponse as BaseGroupResponse,
+} from 'jslib/models/response/groupResponse';
+import { SelectionReadOnly } from '../selectionReadOnly';
+
+export class GroupResponse implements BaseResponse {
+    object: string;
+    id: string;
+    organizationId: string;
+    name: string;
+    accessAll: boolean;
+    externalId: string;
+
+    constructor(response: BaseGroupResponse) {
+        this.object = 'group';
+        this.id = response.id;
+        this.organizationId = response.organizationId;
+        this.name = response.name;
+        this.accessAll = response.accessAll;
+        this.externalId = response.externalId;
+    }
+}
+
+export class GroupDetailsResponse extends GroupResponse implements BaseResponse {
+    collections: SelectionReadOnly[];
+    constructor(response: BaseGroupDetailsResponse) {
+        super(response);
+        this.collections = response.collections.map((r) => new SelectionReadOnly(r.id, r.readOnly));
+    }
+}

--- a/src/program.ts
+++ b/src/program.ts
@@ -231,6 +231,7 @@ export class Program extends BaseProgram {
             .option('--folderid <folderid>', 'Filter items by folder id.')
             .option('--collectionid <collectionid>', 'Filter items by collection id.')
             .option('--organizationid <organizationid>', 'Filter items or collections by organization id.')
+            .option('--groupid <groupid>', 'Filter items or collections by group id.')
             .on('--help', () => {
                 writeLn('\n  Objects:');
                 writeLn('');
@@ -240,6 +241,8 @@ export class Program extends BaseProgram {
                 writeLn('    organizations');
                 writeLn('    org-collections');
                 writeLn('    org-members');
+                writeLn('    groups');
+                writeLn('    group-members');
                 writeLn('');
                 writeLn('  Notes:');
                 writeLn('');
@@ -290,6 +293,7 @@ export class Program extends BaseProgram {
                 writeLn('    organization');
                 writeLn('    template');
                 writeLn('    fingerprint');
+                writeLn('    group');
                 writeLn('');
                 writeLn('  Id:');
                 writeLn('');
@@ -331,6 +335,7 @@ export class Program extends BaseProgram {
                 writeLn('    attachment');
                 writeLn('    folder');
                 writeLn('    org-collection');
+                writeLn('    group');
                 writeLn('');
                 writeLn('  Notes:');
                 writeLn('');
@@ -363,6 +368,8 @@ export class Program extends BaseProgram {
                 writeLn('    item-collections');
                 writeLn('    folder');
                 writeLn('    org-collection');
+                writeLn('    group');
+                writeLn('    group-members');
                 writeLn('');
                 writeLn('  Id:');
                 writeLn('');
@@ -401,6 +408,7 @@ export class Program extends BaseProgram {
                 writeLn('    attachment');
                 writeLn('    folder');
                 writeLn('    org-collection');
+                writeLn('    group');
                 writeLn('');
                 writeLn('  Id:');
                 writeLn('');


### PR DESCRIPTION
This seems to be the last missing piece to use the CLI to manage every part in daily bitwarden usage.

I tested it in our company bitwarden and it works well. The code itself can be improved. Especially by moving the groupResponse part into the jslib and use a similar pattern the rest there does (with Views)
As this is my first contribution I was not 100% sure how to tackle that - so I added it directly here.
Either you can move parts to the jslib or I guess I could do a follow up PR that does that. I tried to code similar to what I found - hope thats fine.