### PR TITLE
add completion generation for zsh

### DIFF
--- a/src/commands/completion.command.ts
+++ b/src/commands/completion.command.ts
@@ -1,0 +1,135 @@
+import * as program from "commander";
+import { Response } from "jslib/cli/models/response";
+import { MessageResponse } from "jslib/cli/models/response/messageResponse";
+
+type Option = {
+    long: string;
+    short: string;
+    description: string;
+};
+
+type Command = {
+    commands?: Command[];
+    options?: Option[];
+    _name: string;
+    _description: string;
+};
+
+const zshCompletion = (rootName: string, rootCommand: Command) => {
+    const renderCommandBlock = (name: string, command: Command): string => {
+        const { commands = [], options = [] } = command;
+        const hasOptions = options.length > 0;
+        const hasCommands = commands.length > 0;
+
+        const _arguments = options
+            .map(({ long, short, description }) => {
+                const aliases = [short, long].filter(Boolean);
+
+                const OPTS = aliases.join(",");
+
+                const DESCRIPTION = `[${description.replace("'", `'"'"'`)}]`;
+
+                return aliases.length > 1
+                    ? `'(${aliases.join(" ")})'{${OPTS}}'${DESCRIPTION}'`
+                    : `'${OPTS}${DESCRIPTION}'`;
+            })
+            .concat(
+                `'(-h --help)'{-h,--help}'[output usage information]'`,
+                hasCommands ? '"1: :->cmnds"' : null,
+                '"*::arg:->args"'
+            )
+            .filter(Boolean);
+
+        const commandBlockFunctionParts = [];
+
+        if (hasCommands) {
+            commandBlockFunctionParts.push("local -a commands");
+        }
+
+        if (hasOptions) {
+            commandBlockFunctionParts.push(
+                `_arguments -C \\\n    ${_arguments.join(` \\\n    `)}`
+            );
+        }
+
+        if (hasCommands) {
+            commandBlockFunctionParts.push(
+                `case $state in
+    cmnds)
+      commands=(
+        ${commands
+            .map(({ _name, _description }) => `"${_name}:${_description}"`)
+            .join("\n        ")}
+      )
+      _describe "command" commands
+      ;;
+  esac
+
+  case "$words[1]" in
+    ${commands
+        .map(({ _name }) =>
+            [`${_name})`, `_${name}_${_name}`, ";;"].join("\n      ")
+        )
+        .join("\n    ")}
+  esac`
+            );
+        }
+
+        const commandBlocParts = [
+            `function _${name} {\n  ${commandBlockFunctionParts.join(
+                "\n\n  "
+            )}\n}`,
+        ];
+
+        if (hasCommands) {
+            commandBlocParts.push(
+                commands
+                    .map((command) =>
+                        renderCommandBlock(`${name}_${command._name}`, command)
+                    )
+                    .join("\n\n")
+            );
+        }
+
+        return commandBlocParts.join("\n\n");
+    };
+
+    const render = () => {
+        return [
+            `#compdef _${rootName} ${rootName}`,
+            "",
+            renderCommandBlock(rootName, rootCommand),
+        ].join("\n");
+    };
+
+    return {
+        render,
+    };
+};
+
+const validShells = ["zsh"];
+
+export class CompletionCommand {
+    constructor() {}
+
+    async run(cmd: program.Command) {
+        const shell: typeof validShells[number] = cmd.shell;
+
+        if (!shell) {
+            return Response.badRequest("`shell` was not provided!");
+        }
+
+        if (!validShells.includes(shell)) {
+            return Response.badRequest(`Unsupported shell!`);
+        }
+
+        let content = "";
+
+        if (shell === "zsh") {
+            content = zshCompletion("bw", cmd.parent).render();
+        }
+
+        const res = new MessageResponse(content, null);
+        return Response.success(res);
+    }
+}

--- a/src/program.ts
+++ b/src/program.ts
@@ -21,6 +21,8 @@ import { ShareCommand } from './commands/share.command';
 import { SyncCommand } from './commands/sync.command';
 import { UnlockCommand } from './commands/unlock.command';
 
+import { CompletionCommand } from './commands/completion.command';
+
 import { LogoutCommand } from 'jslib/cli/commands/logout.command';
 import { UpdateCommand } from 'jslib/cli/commands/update.command';
 
@@ -659,6 +661,26 @@ export class Program extends BaseProgram {
                 const response = await command.run(cmd);
                 this.processResponse(response);
             });
+
+        program
+            .command('completion')
+            .description('Generate shell completions.')
+            .option('--shell <shell>', 'Shell to generate completions for.')
+            .on('--help', () => {
+                writeLn('\n  Notes:');
+                writeLn('');
+                writeLn('    Valid shells are `zsh`.')
+                writeLn('');
+                writeLn('  Examples:');
+                writeLn('');
+                writeLn('    bw completion --shell zsh');
+                writeLn('', true);
+            })
+            .action(async (cmd: program.Command) => {
+                const command = new CompletionCommand();
+                const response = await command.run(cmd);
+                this.processResponse(response);
+            })
 
         program
             .parse(process.argv);


### PR DESCRIPTION
Completion support for ZSH

Previously, #76 took a manual approach for this and was abandoned later (no activity for a long time).

## Usage

**vanilla (.zshrc)**:

Add the following line in your `.zshrc` file:

```shell
eval "$(bw completion --shell zsh); compdef _bw bw;"
```

**vanilla (vendor-completions)**

Run the following command:

```
bw completion --shell zsh | sudo tee /usr/share/zsh/vendor-completions/_bw
```

[**zinit**](https://github.com/zdharma/zinit):

Run the following commands:

```shell
bw completion --shell zsh > ~/.local/share/zsh/completions/_bw
zinit creinstall ~/.local/share/zsh/completions
```

## Screenshots

![Screenshot from 2020-05-24 19-06-00](https://user-images.githubusercontent.com/8050659/82754874-b6562700-9df1-11ea-95f3-a38e76c75e25.png)

![Screenshot from 2020-05-24 19-07-41](https://user-images.githubusercontent.com/8050659/82754906-ec93a680-9df1-11ea-80d6-876d58cc2d09.png)

## Generated Output:

```shell
#compdef _bw bw

function _bw {
  local -a commands

  _arguments -C \
    '--pretty[Format output. JSON is tabbed with two spaces.]' \
    '--raw[Return raw output instead of a descriptive message.]' \
    '--response[Return a JSON formatted version of response output.]' \
    '--quiet[Don'"'"'t return anything to stdout.]' \
    '--nointeraction[Do not prompt for interactive user input.]' \
    '--session[Pass session key instead of reading from env.]' \
    '(-v --version)'{-v,--version}'[output the version number]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "1: :->cmnds" \
    "*::arg:->args"

  case $state in
    cmnds)
      commands=(
        "login:Log into a user account."
        "logout:Log out of the current user account."
        "lock:Lock the vault and destroy active session keys."
        "unlock:Unlock the vault and return a new session key."
        "sync:Pull the latest vault data from server."
        "list:List an array of objects from the vault."
        "get:Get an object from the vault."
        "create:Create an object in the vault."
        "edit:Edit an object from the vault."
        "delete:Delete an object from the vault."
        "restore:Restores an object from the trash."
        "share:Share an item to an organization."
        "confirm:Confirm an object to the organization."
        "import:Import vault data from a file."
        "export:Export vault data to a CSV or JSON file."
        "generate:Generate a password/passphrase."
        "encode:Base 64 encode stdin."
        "config:Configure CLI settings."
        "update:Check for updates."
        "completion:Generate shell completions."
      )
      _describe "command" commands
      ;;
  esac

  case "$words[1]" in
    login)
      _bw_login
      ;;
    logout)
      _bw_logout
      ;;
    lock)
      _bw_lock
      ;;
    unlock)
      _bw_unlock
      ;;
    sync)
      _bw_sync
      ;;
    list)
      _bw_list
      ;;
    get)
      _bw_get
      ;;
    create)
      _bw_create
      ;;
    edit)
      _bw_edit
      ;;
    delete)
      _bw_delete
      ;;
    restore)
      _bw_restore
      ;;
    share)
      _bw_share
      ;;
    confirm)
      _bw_confirm
      ;;
    import)
      _bw_import
      ;;
    export)
      _bw_export
      ;;
    generate)
      _bw_generate
      ;;
    encode)
      _bw_encode
      ;;
    config)
      _bw_config
      ;;
    update)
      _bw_update
      ;;
    completion)
      _bw_completion
      ;;
  esac
}

function _bw_login {
  _arguments -C \
    '--method[Two-step login method.]' \
    '--code[Two-step login code.]' \
    '--check[Check login status.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_logout {
  
}

function _bw_lock {
  
}

function _bw_unlock {
  _arguments -C \
    '--check[Check lock status.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_sync {
  _arguments -C \
    '(-f --force)'{-f,--force}'[Force a full sync.]' \
    '--last[Get the last sync date.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_list {
  _arguments -C \
    '--search[Perform a search on the listed objects.]' \
    '--url[Filter items of type login with a url-match search.]' \
    '--folderid[Filter items by folder id.]' \
    '--collectionid[Filter items by collection id.]' \
    '--organizationid[Filter items or collections by organization id.]' \
    '--trash[Filter items that are deleted and in the trash.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_get {
  _arguments -C \
    '--itemid[Attachment'"'"'s item id.]' \
    '--output[Output directory or filename for attachment.]' \
    '--organizationid[Organization id for an organization object.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_create {
  _arguments -C \
    '--file[Path to file for attachment.]' \
    '--itemid[Attachment'"'"'s item id.]' \
    '--organizationid[Organization id for an organization object.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_edit {
  _arguments -C \
    '--organizationid[Organization id for an organization object.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_delete {
  _arguments -C \
    '--itemid[Attachment'"'"'s item id.]' \
    '--organizationid[Organization id for an organization object.]' \
    '(-p --permanent)'{-p,--permanent}'[Permanently deletes the item instead of soft-deleting it (item only).]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_restore {
  
}

function _bw_share {
  
}

function _bw_confirm {
  _arguments -C \
    '--organizationid[Organization id for an organization object.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_import {
  _arguments -C \
    '--formats[List formats]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_export {
  _arguments -C \
    '--output[Output directory or filename.]' \
    '--format[Export file format.]' \
    '--organizationid[Organization id for an organization.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_generate {
  _arguments -C \
    '(-u --uppercase)'{-u,--uppercase}'[Include uppercase characters.]' \
    '(-l --lowercase)'{-l,--lowercase}'[Include lowercase characters.]' \
    '(-n --number)'{-n,--number}'[Include numeric characters.]' \
    '(-s --special)'{-s,--special}'[Include special characters.]' \
    '(-p --passphrase)'{-p,--passphrase}'[Generate a passphrase.]' \
    '--length[Length of the password.]' \
    '--words[Number of words.]' \
    '--separator[Word separator.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_encode {
  
}

function _bw_config {
  _arguments -C \
    '--web-vault[Provides a custom web vault URL that differs from the base URL.]' \
    '--api[Provides a custom API URL that differs from the base URL.]' \
    '--identity[Provides a custom identity URL that differs from the base URL.]' \
    '--icons[Provides a custom icons service URL that differs from the base URL.]' \
    '--notifications[Provides a custom notifications URL that differs from the base URL.]' \
    '--events[Provides a custom events URL that differs from the base URL.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}

function _bw_update {
  
}

function _bw_completion {
  _arguments -C \
    '--shell[Shell to generate completions for.]' \
    '(-h --help)'{-h,--help}'[output usage information]' \
    "*::arg:->args"
}
```


resolves #75 