### PR TITLE
Add a `--stdout` option to the export command

### DIFF
--- a/src/commands/export.command.ts
+++ b/src/commands/export.command.ts
@@ -43,9 +43,23 @@ export class ExportCommand {
             } catch (e) {
                 return Response.error(e);
             }
-            return await this.saveFile(csv, cmd, format);
+
+            if (!cmd.stdout) {
+                return await this.saveFile(csv, cmd, format);
+            } else {
+                return await this.writeStdout(csv);
+            }
         } else {
             return Response.error('Invalid master password.');
+        }
+    }
+
+    async writeStdout(csv: string): Promise<Response> {
+        try {
+            await process.stdout.write(csv);
+            return Response.success();
+        } catch (e) {
+            return Response.error(e.toString());
         }
     }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -532,6 +532,7 @@ export class Program extends BaseProgram {
             .command('export [password]')
             .description('Export vault data to a CSV or JSON file.')
             .option('--output <output>', 'Output directory or filename.')
+            .option('--stdout', 'Output to the standard output (overrides --output).')
             .option('--format <format>', 'Export file format.')
             .option('--organizationid <organizationid>', 'Organization id for an organization.')
             .on('--help', () => {


### PR DESCRIPTION
This new option `--stdout` overrides `--output`, by instructing `bw` to write the exported content to the standard output, instead of a file (either implicit or explicitly named).

Please note that I'm not used to developing with either Node.js or TypeScript, so while I've tested this change, it might not be sound. I'm open to making changes myself to this PR, of course, but I'd appreciate some extra advice in that case.

(Related to issue #103)

