### PR TITLE
Reworked passphrase generation

### DIFF
--- a/src/commands/generate.command.ts
+++ b/src/commands/generate.command.ts
@@ -9,13 +9,32 @@ export class GenerateCommand {
     constructor(private passwordGenerationService: PasswordGenerationService) { }
 
     async run(cmd: program.Command): Promise<Response> {
+        // Check if options are correct
+        if (cmd.passphrase) {
+            if (cmd.words && cmd.length) {
+                return Response.error(`You can't limit words and length at the same time for passphrases generation.`);
+            }
+            if (cmd.uppercase || cmd.lowercase || cmd.special) {
+                return Response.error('You used options, not viable for passphrase generation.');
+            }
+            if (cmd.length) {
+                cmd.type = 'passphrase_limited';
+            }
+        } else { // Password
+            if (cmd.capitalize || cmd.words || cmd.separator) {
+                return Response.error('You used options, not viable for password generation.');
+            }
+        }
+
         const options = {
             uppercase: cmd.uppercase || false,
+            capitalize: cmd.capitalize || false,
             lowercase: cmd.lowercase || false,
             number: cmd.number || false,
+            includeNumber: cmd.number || false,
             special: cmd.special || false,
             length: cmd.length || 14,
-            type: cmd.passphrase ? 'passphrase' : 'password',
+            type: cmd.type || (cmd.passphrase ? 'passphrase' : 'password'),
             wordSeparator: cmd.separator == null ? '-' : cmd.separator,
             numWords: cmd.words || 3,
         };

--- a/src/program.ts
+++ b/src/program.ts
@@ -559,14 +559,15 @@ export class Program extends BaseProgram {
         program
             .command('generate')
             .description('Generate a password/passphrase.')
-            .option('-u, --uppercase', 'Include uppercase characters.')
-            .option('-l, --lowercase', 'Include lowercase characters.')
-            .option('-n, --number', 'Include numeric characters.')
-            .option('-s, --special', 'Include special characters.')
-            .option('-p, --passphrase', 'Generate a passphrase.')
             .option('--length <length>', 'Length of the password.')
-            .option('--words <words>', 'Number of words.')
-            .option('--separator <separator>', 'Word separator.')
+            .option('-u, --uppercase', 'Include uppercase characters. Not viable for passphrases.')
+            .option('-l, --lowercase', 'Include lowercase characters. Not viable for passphrases.')
+            .option('-s, --special', 'Include special characters. Not viable for passphrases.\n')
+            .option('-n, --number', 'Include numeric characters. Single character for passphrases.\n')
+            .option('-p, --passphrase', 'Generate a passphrase.')
+            .option('-c, --capitalize', 'Passphrase words shall begin with capital characters. Only viable for passphrases.')
+            .option('--words <words>', 'Number of words. Only viable for passphrases.')
+            .option('--separator <separator>', 'Word separator. Only viable for passphrases.')
             .on('--help', () => {
                 writeLn('\n  Notes:');
                 writeLn('');
@@ -584,6 +585,7 @@ export class Program extends BaseProgram {
                 writeLn('    bw generate -ul');
                 writeLn('    bw generate -p --separator _');
                 writeLn('    bw generate -p --words 5 --separator space');
+                writeLn('    bw generate -p -n -c --length 20');
                 writeLn('', true);
             })
             .action(async (cmd) => {


### PR DESCRIPTION
- Allow passphrases with length
- Warn, if password options are used for passphrases
- Warn, if passphrase options are used for passwords
- Extended help for generation accordingly
- Added another example for passphrases

According to: https://github.com/bitwarden/jslib/pull/109