### PR TITLE
Add status command

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,0 +1,31 @@
+import * as program from 'commander';
+
+import { UserService, VaultTimeoutService } from 'jslib/abstractions';
+import { Response } from 'jslib/cli/models/response';
+import { TemplateResponse } from '../models/response/templateResponse';
+
+export class StatusCommand {
+    constructor(private userService: UserService, private vaultTimeoutService: VaultTimeoutService) {
+    }
+
+    async run(cmd: program.Command): Promise<Response> {
+        const status = await this.status();
+        return Response.success(new TemplateResponse({
+            status: status,
+        }));
+    }
+
+    async status(): Promise<string> {
+        const isAuthed = await this.userService.isAuthenticated();
+        if (!isAuthed) {
+            return 'unauthenticated';
+        }
+
+        const isLocked = await this.vaultTimeoutService.isLocked();
+        if (isLocked) {
+            return 'locked';
+        } else {
+            return 'unlocked';
+        }
+    }
+}

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,21 +1,46 @@
 import * as program from 'commander';
 
-import { UserService, VaultTimeoutService } from 'jslib/abstractions';
+import { EnvironmentService, SyncService, UserService, VaultTimeoutService } from 'jslib/abstractions';
 import { Response } from 'jslib/cli/models/response';
 import { TemplateResponse } from '../models/response/templateResponse';
 
 export class StatusCommand {
-    constructor(private userService: UserService, private vaultTimeoutService: VaultTimeoutService) {
+    constructor(
+        private envService: EnvironmentService,
+        private syncService: SyncService,
+        private userService: UserService,
+        private vaultTimeoutService: VaultTimeoutService) {
     }
 
     async run(cmd: program.Command): Promise<Response> {
-        const status = await this.status();
-        return Response.success(new TemplateResponse({
-            status: status,
-        }));
+        try {
+            const baseUrl = this.baseUrl();
+            const status = await this.status();
+            const lastSync = await this.syncService.getLastSync();
+            const userId = await this.userService.getUserId();
+            const email = await this.userService.getEmail();
+
+            return Response.success(new TemplateResponse({
+                serverUrl: baseUrl,
+                lastSync: lastSync,
+                userEmail: email,
+                userId: userId,
+                status: status,
+            }));
+        } catch (e) {
+            return Response.error(e);
+        }
     }
 
-    async status(): Promise<string> {
+    private baseUrl(): string {
+        let url = this.envService.baseUrl;
+        if (url == null) {
+            url = 'https://bitwarden.com';
+        }
+        return url;
+    }
+
+    private async status(): Promise<string> {
         const isAuthed = await this.userService.isAuthenticated();
         if (!isAuthed) {
             return 'unauthenticated';

--- a/src/program.ts
+++ b/src/program.ts
@@ -18,6 +18,7 @@ import { LockCommand } from './commands/lock.command';
 import { LoginCommand } from './commands/login.command';
 import { RestoreCommand } from './commands/restore.command';
 import { ShareCommand } from './commands/share.command';
+import { StatusCommand } from './commands/status.command';
 import { SyncCommand } from './commands/sync.command';
 import { UnlockCommand } from './commands/unlock.command';
 
@@ -678,6 +679,14 @@ export class Program extends BaseProgram {
             })
             .action(async (cmd: program.Command) => {
                 const command = new CompletionCommand();
+                const response = await command.run(cmd);
+                this.processResponse(response);
+            });
+
+        program
+            .command('status')
+            .action(async (cmd: program.Command) => {
+                const command = new StatusCommand(this.main.userService, this.main.vaultTimeoutService);
                 const response = await command.run(cmd);
                 this.processResponse(response);
             });

--- a/src/program.ts
+++ b/src/program.ts
@@ -685,6 +685,26 @@ export class Program extends BaseProgram {
 
         program
             .command('status')
+            .description('Show server, last sync, user information, and vault status.')
+            .on('--help', () => {
+                writeLn('');
+                writeLn('');
+                writeLn('  Example return value:');
+                writeLn('');
+                writeLn('    {');
+                writeLn('      "serverUrl": "https://bitwarden.example.com",');
+                writeLn('      "lastSync": "2020-06-16T06:33:51.419Z",');
+                writeLn('      "userEmail": "user@example.com,');
+                writeLn('      "userId": "00000000-0000-0000-0000-000000000000",');
+                writeLn('      "status": "locked"');
+                writeLn('    }');
+                writeLn('');
+                writeLn('  The "status" is one of "unauthenticated", "locked", "unlocked":');
+                writeLn('    - "unauthenticated" when you are not logged in');
+                writeLn('    - "locked" when you are logged in and the vault is locked');
+                writeLn('    - "unlocked" when you are logged in and the vault is unlocked');
+                writeLn('', true);
+            })
             .action(async (cmd: program.Command) => {
                 const command = new StatusCommand(
                     this.main.environmentService,

--- a/src/program.ts
+++ b/src/program.ts
@@ -686,7 +686,11 @@ export class Program extends BaseProgram {
         program
             .command('status')
             .action(async (cmd: program.Command) => {
-                const command = new StatusCommand(this.main.userService, this.main.vaultTimeoutService);
+                const command = new StatusCommand(
+                    this.main.environmentService,
+                    this.main.syncService,
+                    this.main.userService,
+                    this.main.vaultTimeoutService);
                 const response = await command.run(cmd);
                 this.processResponse(response);
             });


### PR DESCRIPTION
This is a shorthand that displays server URL, last sync time, user email and ID, and vault status as output of a single command. This resolves bitwarden/cli#128.

Example usage:

    $ bw status | jq
    {
      "serverUrl": "https://bitwarden.example.com",
      "lastSync": "2020-06-16T06:33:51.419Z",
      "userEmail": "user@example.com",
      "userId": "00000000-0000-0000-0000-000000000000",
      "status": "locked"
    }
