### PR TITLE
Export to stdout

### DIFF
--- a/src/commands/export.command.ts
+++ b/src/commands/export.command.ts
@@ -35,27 +35,24 @@ export class ExportCommand {
             if (cmd.organizationid != null && !Utils.isGuid(cmd.organizationid)) {
                 return Response.error('`' + cmd.organizationid + '` is not a GUID.');
             }
-            let csv: string = null;
+            let exportContent: string = null;
             try {
-                csv = cmd.organizationid != null ?
+                exportContent = cmd.organizationid != null ?
                     await this.exportService.getOrganizationExport(cmd.organizationid, format) :
                     await this.exportService.getExport(format);
             } catch (e) {
                 return Response.error(e);
             }
-            return await this.saveFile(csv, cmd, format);
+            return await this.saveFile(exportContent, cmd, format);
         } else {
             return Response.error('Invalid master password.');
         }
     }
 
-    async saveFile(csv: string, cmd: program.Command, format: string): Promise<Response> {
+    async saveFile(exportContent: string, cmd: program.Command, format: string): Promise<Response> {
         try {
-            const filePath = await CliUtils.saveFile(csv, cmd.output,
-                this.exportService.getFileName(cmd.organizationid != null ? 'org' : null, format));
-            const res = new MessageResponse('Saved ' + filePath, null);
-            res.raw = filePath;
-            return Response.success(res);
+            const fileName = this.exportService.getFileName(cmd.organizationid != null ? 'org' : null, format);
+            return await CliUtils.saveResultToFile(exportContent, cmd.output, fileName);
         } catch (e) {
             return Response.error(e.toString());
         }

--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -283,10 +283,7 @@ export class GetCommand {
             const key = attachments[0].key != null ? attachments[0].key :
                 await this.cryptoService.getOrgKey(cipher.organizationId);
             const decBuf = await this.cryptoService.decryptFromBytes(buf, key);
-            const filePath = await CliUtils.saveFile(Buffer.from(decBuf), cmd.output, attachments[0].fileName);
-            const res = new MessageResponse('Saved ' + filePath, null);
-            res.raw = filePath;
-            return Response.success(res);
+            return await CliUtils.saveResultToFile(Buffer.from(decBuf), cmd.output, attachments[0].fileName);
         } catch (e) {
             if (typeof (e) === 'string') {
                 return Response.error(e);

--- a/src/program.ts
+++ b/src/program.ts
@@ -301,6 +301,9 @@ export class Program extends BaseProgram {
                 writeLn('');
                 writeLn('    Search term or object\'s globally unique `id`.');
                 writeLn('');
+                writeLn('    If raw output is specified and no output filename or directory is given for');
+                writeLn('    an attachment query, the attachment content is written to stdout.');
+                writeLn('');
                 writeLn('  Examples:');
                 writeLn('');
                 writeLn('    bw get item 99ee88d2-6046-4ea7-92c2-acac464b1412');
@@ -539,6 +542,9 @@ export class Program extends BaseProgram {
                 writeLn('\n  Notes:');
                 writeLn('');
                 writeLn('    Valid formats are `csv` and `json`. Default format is `csv`.');
+                writeLn('');
+                writeLn('    If raw output is specified and no output filename or directory is given, the');
+                writeLn('    result is written to stdout.');
                 writeLn('');
                 writeLn('  Examples:');
                 writeLn('');


### PR DESCRIPTION
To help with automations via script, I added the ability to write attachments and exports directly to stdout.
Since `raw` output of the filename is not really that helpful for these cases, I modified the flow so that the combination of no explicit output being given (`--output` is omitted) and `--raw` being specified, leads to the content being written to stdout.

The code should explain itself (together with the changes to the help texts).

I also took the liberty to add tsdoc comments for two methods that are now not so easy to distinguish without explanation and fixed a little naming-obscurity ("csv" was used even though it can contain JSON).