### PR TITLE
add network-bind interface to support sso

### DIFF
--- a/stores/snap/snapcraft.yaml
+++ b/stores/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ confinement: strict
 apps:
   bw:
     command: bw
-    plugs: [network, home]
+    plugs: [network, home, network-bind]
 parts:
   bw:
     plugin: dump


### PR DESCRIPTION
resolves #166

Snap packages cannot create a webserver in their sandbox without permission from the network-bind interface