### PR TITLE
set collection view id from response

### DIFF
--- a/src/commands/create.command.ts
+++ b/src/commands/create.command.ts
@@ -154,8 +154,10 @@ export class CreateCommand {
             request.name = (await this.cryptoService.encrypt(req.name, orgKey)).encryptedString;
             request.externalId = req.externalId;
             request.groups = groups;
-            await this.apiService.postCollection(req.organizationId, request);
-            const res = new OrganizationCollectionResponse(Collection.toView(req), groups);
+            const response = await this.apiService.postCollection(req.organizationId, request);
+            const view = Collection.toView(req);
+            view.id = response.id;
+            const res = new OrganizationCollectionResponse(view, groups);
             return Response.success(res);
         } catch (e) {
             return Response.error(e);

--- a/src/commands/edit.command.ts
+++ b/src/commands/edit.command.ts
@@ -152,8 +152,10 @@ export class EditCommand {
             request.name = (await this.cryptoService.encrypt(req.name, orgKey)).encryptedString;
             request.externalId = req.externalId;
             request.groups = groups;
-            await this.apiService.putCollection(req.organizationId, id, request);
-            const res = new OrganizationCollectionResponse(Collection.toView(req), groups);
+            const response = await this.apiService.putCollection(req.organizationId, id, request);
+            const view = Collection.toView(req);
+            view.id = response.id;
+            const res = new OrganizationCollectionResponse(view, groups);
             return Response.success(res);
         } catch (e) {
             return Response.error(e);


### PR DESCRIPTION
resolves #175

The org-collection commends invoke the API directly. The id was not getting properly set from the response received back from the server.