### PR TITLE
Implement User-based API Keys

### DIFF
--- a/src/commands/login.command.ts
+++ b/src/commands/login.command.ts
@@ -30,7 +30,7 @@ export class LoginCommand extends BaseLoginCommand {
         };
         this.success = async () => {
             await syncService.fullSync(true);
-            if (this.cmd.sso != null && this.canInteract) {
+            if ((this.cmd.sso != null || this.cmd.apiKey != null) && this.canInteract) {
                 const res = new MessageResponse('You are logged in!', '\n' +
                     'To unlock your vault, use the `unlock` command. ex:\n' +
                     '$ bw unlock');

--- a/src/commands/login.command.ts
+++ b/src/commands/login.command.ts
@@ -30,7 +30,7 @@ export class LoginCommand extends BaseLoginCommand {
         };
         this.success = async () => {
             await syncService.fullSync(true);
-            if ((this.cmd.sso != null || this.cmd.apiKey != null) && this.canInteract) {
+            if ((this.cmd.sso != null || this.cmd.apikey != null) && this.canInteract) {
                 const res = new MessageResponse('You are logged in!', '\n' +
                     'To unlock your vault, use the `unlock` command. ex:\n' +
                     '$ bw unlock');

--- a/src/program.ts
+++ b/src/program.ts
@@ -108,6 +108,7 @@ export class Program extends BaseProgram {
             .option('--method <method>', 'Two-step login method.')
             .option('--code <code>', 'Two-step login code.')
             .option('--sso', 'Log in with Single-Sign On.')
+            .option('--apiKey', 'Log in with an Api Key.')
             .option('--check', 'Check login status.', async () => {
                 const authed = await this.main.userService.isAuthenticated();
                 if (authed) {

--- a/src/program.ts
+++ b/src/program.ts
@@ -108,7 +108,7 @@ export class Program extends BaseProgram {
             .option('--method <method>', 'Two-step login method.')
             .option('--code <code>', 'Two-step login code.')
             .option('--sso', 'Log in with Single-Sign On.')
-            .option('--apiKey', 'Log in with an Api Key.')
+            .option('--apikey', 'Log in with an Api Key.')
             .option('--check', 'Check login status.', async () => {
                 const authed = await this.main.userService.isAuthenticated();
                 if (authed) {


### PR DESCRIPTION
# Description
In order to facilitate the new Force SSO policy enterprise users will need an alternative authentication method to use the Bitwarden CLI: user owned client keys.

https://app.asana.com/0/1195018406457675/1188892364010726/f

# Code Changes 
1. Ad `--apiKey` option to `login` command
2. ???
3. Profit 💰

# Screenshots
![Screen Shot 2020-11-04 at 1 24 44 PM](https://user-images.githubusercontent.com/15897251/98181748-07eefb80-1ed2-11eb-8fb1-a234b89dc9d8.png)

# Sibling PRs
https://github.com/bitwarden/server/pull/981
https://github.com/bitwarden/jslib/pull/197
https://github.com/bitwarden/web/pull/688