### PR TITLE
Bump https-proxy-agent dep. to 5.0.0 - This PR hopes to fix #181

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@bitwarden/cli",
     "description": "A secure and free password manager for all of your devices.",
-    "version": "1.12.1",
+    "version": "1.12.2",
     "keywords": [
         "bitwarden",
         "password",
@@ -76,7 +76,7 @@
         "chalk": "2.4.1",
         "commander": "2.18.0",
         "form-data": "2.3.2",
-        "https-proxy-agent": "4.0.0",
+        "https-proxy-agent": "5.0.0",
         "inquirer": "6.2.0",
         "jsdom": "13.2.0",
         "lowdb": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@bitwarden/cli",
     "description": "A secure and free password manager for all of your devices.",
-    "version": "1.12.2",
+    "version": "1.12.1",
     "keywords": [
         "bitwarden",
         "password",


### PR DESCRIPTION
Hi,

This PR is raised to bump a NodeJS dependency which people like us who use bitwarden CLI at work heavily rely on. As described in #181 [this library](https://www.npmjs.com/package/https-proxy-agent) introduced a bug for which we cannot log in successfully when running CLI commands behind an HTTP proxy.

I also bumped the third (patch I guess?) version of the tool.

Please, do review this small code change and let me know if I had to also update the `package-lock.json` - I don't do much JS lately.

Cheers,