### PR TITLE
SyncCommand: Pass allowThrowOnError to fullSync

### DIFF
--- a/src/commands/sync.command.ts
+++ b/src/commands/sync.command.ts
@@ -15,11 +15,11 @@ export class SyncCommand {
         }
 
         try {
-            const result = await this.syncService.fullSync(cmd.force || false);
+            const result = await this.syncService.fullSync(cmd.force || false, true);
             const res = new MessageResponse('Syncing complete.', null);
             return Response.success(res);
         } catch (e) {
-            return Response.error(e);
+            return Response.error('Syncing failed: ' + e.toString());
         }
     }
 


### PR DESCRIPTION
This intends to make explicit calls to bw sync
throw if the syncing can not be performed,
fixes https://github.com/bitwarden/cli/issues/129.

See also https://github.com/bitwarden/jslib/pull/207 (although the patches are independent of each other).