### PR TITLE
Add null check when getting attachment from item

### DIFF
--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -253,7 +253,7 @@ export class GetCommand {
         }
 
         const cipher = await this.getCipherView(itemId);
-        if (cipher == null || Array.isArray(cipher) || cipher.attachments.length === 0) {
+        if (cipher == null || Array.isArray(cipher) || cipher.attachments == null || cipher.attachments.length === 0) {
             return Response.error('No attachments available for this item.');
         }
 


### PR DESCRIPTION
## Objective
Fix #212 - Getting attachment from item without attachments results in exception.

## Code changes
Add extra null check to catch `cipher` objects without an `attachment` property.