### PR TITLE
Clarify help text for --raw option to bw export

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -548,12 +548,13 @@ export class Program extends BaseProgram {
                 writeLn('');
                 writeLn('    Valid formats are `csv`, `json`, `encrypted_json`. Default format is `csv`.');
                 writeLn('');
-                writeLn('    If raw output is specified and no output filename or directory is given, the');
+                writeLn('    If --raw option is specified and no output filename or directory is given, the');
                 writeLn('    result is written to stdout.');
                 writeLn('');
                 writeLn('  Examples:');
                 writeLn('');
                 writeLn('    bw export');
+                writeLn('    bw --raw export');
                 writeLn('    bw export myPassword321');
                 writeLn('    bw export myPassword321 --format json');
                 writeLn('    bw export --output ./exp/bw.csv');


### PR DESCRIPTION
I had a hard time finding how to export my vault to stdout rather than a file on disk (see https://community.bitwarden.com/t/allow-exporting-to-vault-to-stdout/3772/3 ), so this is a tiny fix to mention that the --raw option makes bw export do this.