### PR TITLE
Fix: don't check filename by index when listing attachments

### DIFF
--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -257,11 +257,17 @@ export class GetCommand {
             return Response.error('No attachments available for this item.');
         }
 
-        const attachments = cipher.attachments.filter((a) => a.id.toLowerCase() === id ||
-            (a.fileName != null && a.fileName.toLowerCase() === id));
+        let attachments = cipher.attachments.filter((a) => a.id.toLowerCase() === id ||
+            (a.fileName != null && a.fileName.toLowerCase().indexOf(id) > -1));
         if (attachments.length === 0) {
             return Response.error('Attachment `' + id + '` was not found.');
         }
+
+        const exactMatches = attachments.filter((a) => a.fileName.toLowerCase() === id)
+        if (exactMatches.length === 1) {
+            attachments = exactMatches;
+        }
+
         if (attachments.length > 1) {
             return Response.multipleResults(attachments.map((a) => a.id));
         }

--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -258,7 +258,7 @@ export class GetCommand {
         }
 
         const attachments = cipher.attachments.filter((a) => a.id.toLowerCase() === id ||
-            (a.fileName != null && a.fileName.toLowerCase().indexOf(id) > -1));
+            (a.fileName != null && a.fileName.toLowerCase() === id));
         if (attachments.length === 0) {
             return Response.error('Attachment `' + id + '` was not found.');
         }


### PR DESCRIPTION
This fixes an issue when multiple files are attached and they have a similar filename, such as `id_rsa` and `id_rsa.pub`. Before this fix, when running `get attachment id_rsa.pub --itemid <id>` worked fine, however, when doing the same query with `id_rsa` instead, it returned a `multipleResults` error.

I caught this issue while [implementing](https://github.com/twpayne/chezmoi/pull/1019) `bitwardenAttachment` Go template in `chezmoi`. 