### PR TITLE
Ban single paren arrow functions

### DIFF
--- a/src/bw.ts
+++ b/src/bw.ts
@@ -104,7 +104,7 @@ export class Main {
         this.i18nService = new I18nService('en', './locales');
         this.platformUtilsService = new CliPlatformUtilsService('cli', packageJson);
         this.logService = new ConsoleLogService(this.platformUtilsService.isDev(),
-            (level) => process.env.BITWARDENCLI_DEBUG !== 'true' && level <= LogLevelType.Info);
+            level => process.env.BITWARDENCLI_DEBUG !== 'true' && level <= LogLevelType.Info);
         this.cryptoFunctionService = new NodeCryptoFunctionService();
         this.storageService = new LowdbStorageService(this.logService, null, p, true);
         this.secureStorageService = new NodeEnvSecureStorageService(this.storageService, this.logService,

--- a/src/commands/completion.command.ts
+++ b/src/commands/completion.command.ts
@@ -101,7 +101,7 @@ export class CompletionCommand {
 
         if (hasCommands) {
             commandBlocParts.push(
-                commands.map((c) => this.renderCommandBlock(`${name}_${c._name}`, c)).join('\n\n'),
+                commands.map(c => this.renderCommandBlock(`${name}_${c._name}`, c)).join('\n\n'),
             );
         }
 

--- a/src/commands/create.command.ts
+++ b/src/commands/create.command.ts
@@ -149,7 +149,7 @@ export class CreateCommand {
             }
 
             const groups = req.groups == null ? null :
-                req.groups.map((g) => new SelectionReadOnlyRequest(g.id, g.readOnly, g.hidePasswords));
+                req.groups.map(g => new SelectionReadOnlyRequest(g.id, g.readOnly, g.hidePasswords));
             const request = new CollectionRequest();
             request.name = (await this.cryptoService.encrypt(req.name, orgKey)).encryptedString;
             request.externalId = req.externalId;

--- a/src/commands/delete.command.ts
+++ b/src/commands/delete.command.ts
@@ -65,7 +65,7 @@ export class DeleteCommand {
             return Response.error('No attachments available for this item.');
         }
 
-        const attachments = cipher.attachments.filter((a) => a.id.toLowerCase() === id);
+        const attachments = cipher.attachments.filter(a => a.id.toLowerCase() === id);
         if (attachments.length === 0) {
             return Response.error('Attachment `' + id + '` was not found.');
         }

--- a/src/commands/edit.command.ts
+++ b/src/commands/edit.command.ts
@@ -147,7 +147,7 @@ export class EditCommand {
             }
 
             const groups = req.groups == null ? null :
-                req.groups.map((g) => new SelectionReadOnlyRequest(g.id, g.readOnly, g.hidePasswords));
+                req.groups.map(g => new SelectionReadOnlyRequest(g.id, g.readOnly, g.hidePasswords));
             const request = new CollectionRequest();
             request.name = (await this.cryptoService.encrypt(req.name, orgKey)).encryptedString;
             request.externalId = req.externalId;

--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -137,7 +137,7 @@ export class GetCommand extends DownloadCommand {
                 }
             }
             if (Array.isArray(decCipher)) {
-                return Response.multipleResults(decCipher.map((c) => c.id));
+                return Response.multipleResults(decCipher.map(c => c.id));
             }
         }
         const res = new CipherResponse(decCipher);
@@ -146,7 +146,7 @@ export class GetCommand extends DownloadCommand {
 
     private async getUsername(id: string) {
         const cipherResponse = await this.getCipher(id,
-            (c) => c.type === CipherType.Login && !Utils.isNullOrWhitespace(c.login.username));
+            c => c.type === CipherType.Login && !Utils.isNullOrWhitespace(c.login.username));
         if (!cipherResponse.success) {
             return cipherResponse;
         }
@@ -166,7 +166,7 @@ export class GetCommand extends DownloadCommand {
 
     private async getPassword(id: string) {
         const cipherResponse = await this.getCipher(id,
-            (c) => c.type === CipherType.Login && !Utils.isNullOrWhitespace(c.login.password));
+            c => c.type === CipherType.Login && !Utils.isNullOrWhitespace(c.login.password));
         if (!cipherResponse.success) {
             return cipherResponse;
         }
@@ -186,7 +186,7 @@ export class GetCommand extends DownloadCommand {
 
     private async getUri(id: string) {
         const cipherResponse = await this.getCipher(id,
-            (c) => c.type === CipherType.Login && c.login.uris != null && c.login.uris.length > 0 &&
+            c => c.type === CipherType.Login && c.login.uris != null && c.login.uris.length > 0 &&
                 c.login.uris[0].uri !== '');
         if (!cipherResponse.success) {
             return cipherResponse;
@@ -207,7 +207,7 @@ export class GetCommand extends DownloadCommand {
 
     private async getTotp(id: string) {
         const cipherResponse = await this.getCipher(id,
-            (c) => c.type === CipherType.Login && !Utils.isNullOrWhitespace(c.login.totp));
+            c => c.type === CipherType.Login && !Utils.isNullOrWhitespace(c.login.totp));
         if (!cipherResponse.success) {
             return cipherResponse;
         }
@@ -266,19 +266,19 @@ export class GetCommand extends DownloadCommand {
             return Response.error('No attachments available for this item.');
         }
 
-        let attachments = cipher.attachments.filter((a) => a.id.toLowerCase() === id ||
+        let attachments = cipher.attachments.filter(a => a.id.toLowerCase() === id ||
             (a.fileName != null && a.fileName.toLowerCase().indexOf(id) > -1));
         if (attachments.length === 0) {
             return Response.error('Attachment `' + id + '` was not found.');
         }
 
-        const exactMatches = attachments.filter((a) => a.fileName.toLowerCase() === id)
+        const exactMatches = attachments.filter((a) => a.fileName.toLowerCase() === id);
         if (exactMatches.length === 1) {
             attachments = exactMatches;
         }
 
         if (attachments.length > 1) {
-            return Response.multipleResults(attachments.map((a) => a.id));
+            return Response.multipleResults(attachments.map(a => a.id));
         }
 
         if (!(await this.userService.canAccessPremium())) {
@@ -304,7 +304,7 @@ export class GetCommand extends DownloadCommand {
             let folders = await this.folderService.getAllDecrypted();
             folders = CliUtils.searchFolders(folders, id);
             if (folders.length > 1) {
-                return Response.multipleResults(folders.map((f) => f.id));
+                return Response.multipleResults(folders.map(f => f.id));
             }
             if (folders.length > 0) {
                 decFolder = folders[0];
@@ -329,7 +329,7 @@ export class GetCommand extends DownloadCommand {
             let collections = await this.collectionService.getAllDecrypted();
             collections = CliUtils.searchCollections(collections, id);
             if (collections.length > 1) {
-                return Response.multipleResults(collections.map((c) => c.id));
+                return Response.multipleResults(collections.map(c => c.id));
             }
             if (collections.length > 0) {
                 decCollection = collections[0];
@@ -364,7 +364,7 @@ export class GetCommand extends DownloadCommand {
             decCollection.name = await this.cryptoService.decryptToUtf8(
                 new CipherString(response.name), orgKey);
             const groups = response.groups == null ? null :
-                response.groups.map((g) => new SelectionReadOnly(g.id, g.readOnly, g.hidePasswords));
+                response.groups.map(g => new SelectionReadOnly(g.id, g.readOnly, g.hidePasswords));
             const res = new OrganizationCollectionResponse(decCollection, groups);
             return Response.success(res);
         } catch (e) {
@@ -380,7 +380,7 @@ export class GetCommand extends DownloadCommand {
             let orgs = await this.userService.getAllOrganizations();
             orgs = CliUtils.searchOrganizations(orgs, id);
             if (orgs.length > 1) {
-                return Response.multipleResults(orgs.map((c) => c.id));
+                return Response.multipleResults(orgs.map(c => c.id));
             }
             if (orgs.length > 0) {
                 org = orgs[0];

--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -272,7 +272,7 @@ export class GetCommand extends DownloadCommand {
             return Response.error('Attachment `' + id + '` was not found.');
         }
 
-        const exactMatches = attachments.filter((a) => a.fileName.toLowerCase() === id);
+        const exactMatches = attachments.filter(a => a.fileName.toLowerCase() === id);
         if (exactMatches.length === 1) {
             attachments = exactMatches;
         }

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -50,7 +50,7 @@ export class ImportCommand {
     private async list() {
         const options = this.importService.getImportOptions().sort((a, b) => {
             return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
-        }).map((option) => option.id).join('\n');
+        }).map(option => option.id).join('\n');
         const res = new MessageResponse('Supported input formats:', options);
         res.raw = options;
         return Response.success(res);

--- a/src/commands/list.command.ts
+++ b/src/commands/list.command.ts
@@ -112,7 +112,7 @@ export class ListCommand {
             ciphers = this.searchService.searchCiphersBasic(ciphers, options.search, options.trash);
         }
 
-        const res = new ListResponse(ciphers.map((o) => new CipherResponse(o)));
+        const res = new ListResponse(ciphers.map(o => new CipherResponse(o)));
         return Response.success(res);
     }
 
@@ -123,7 +123,7 @@ export class ListCommand {
             folders = CliUtils.searchFolders(folders, options.search);
         }
 
-        const res = new ListResponse(folders.map((o) => new FolderResponse(o)));
+        const res = new ListResponse(folders.map(o => new FolderResponse(o)));
         return Response.success(res);
     }
 
@@ -143,7 +143,7 @@ export class ListCommand {
             collections = CliUtils.searchCollections(collections, options.search);
         }
 
-        const res = new ListResponse(collections.map((o) => new CollectionResponse(o)));
+        const res = new ListResponse(collections.map(o => new CollectionResponse(o)));
         return Response.success(res);
     }
 
@@ -172,7 +172,7 @@ export class ListCommand {
             if (options.search != null && options.search.trim() !== '') {
                 decCollections = CliUtils.searchCollections(decCollections, options.search);
             }
-            const res = new ListResponse(decCollections.map((o) => new CollectionResponse(o)));
+            const res = new ListResponse(decCollections.map(o => new CollectionResponse(o)));
             return Response.success(res);
         } catch (e) {
             return Response.error(e);
@@ -216,7 +216,7 @@ export class ListCommand {
             organizations = CliUtils.searchOrganizations(organizations, options.search);
         }
 
-        const res = new ListResponse(organizations.map((o) => new OrganizationResponse(o)));
+        const res = new ListResponse(organizations.map(o => new OrganizationResponse(o)));
         return Response.success(res);
     }
 }

--- a/src/commands/list.command.ts
+++ b/src/commands/list.command.ts
@@ -66,7 +66,7 @@ export class ListCommand {
         }
 
         if (options.folderid != null || options.collectionid != null || options.organizationid != null) {
-            ciphers = ciphers.filter((c) => {
+            ciphers = ciphers.filter(c => {
                 if (options.trash !== c.isDeleted) {
                     return false;
                 }
@@ -105,7 +105,7 @@ export class ListCommand {
                 return false;
             });
         } else if (options.search == null || options.search.trim() === '') {
-            ciphers = ciphers.filter((c) => options.trash === c.isDeleted);
+            ciphers = ciphers.filter(c => options.trash === c.isDeleted);
         }
 
         if (options.search != null && options.search.trim() !== '') {
@@ -131,7 +131,7 @@ export class ListCommand {
         let collections = await this.collectionService.getAllDecrypted();
 
         if (options.organizationid != null) {
-            collections = collections.filter((c) => {
+            collections = collections.filter(c => {
                 if (options.organizationid === c.organizationId) {
                     return true;
                 }
@@ -166,7 +166,7 @@ export class ListCommand {
             } else {
                 response = await this.apiService.getUserCollections();
             }
-            const collections = response.data.filter((c) => c.organizationId === options.organizationid).map((r) =>
+            const collections = response.data.filter(c => c.organizationId === options.organizationid).map(r =>
                 new Collection(new CollectionData(r as ApiCollectionDetailsResponse)));
             let decCollections = await this.collectionService.decryptMany(collections);
             if (options.search != null && options.search.trim() !== '') {
@@ -193,7 +193,7 @@ export class ListCommand {
 
         try {
             const response = await this.apiService.getOrganizationUsers(options.organizationid);
-            const res = new ListResponse(response.data.map((r) => {
+            const res = new ListResponse(response.data.map(r => {
                 const u = new OrganizationUserResponse();
                 u.email = r.email;
                 u.name = r.name;

--- a/src/commands/send/create.command.ts
+++ b/src/commands/send/create.command.ts
@@ -73,7 +73,7 @@ export class SendCreateCommand {
                     return Response.badRequest('Must specify a file to Send either with the --file option or in the encoded json');
                 }
 
-                req.file.fileName = path.basename(filePath)
+                req.file.fileName = path.basename(filePath);
                 break;
             case SendType.Text:
                 if (text == null) {

--- a/src/models/response/cipherResponse.ts
+++ b/src/models/response/cipherResponse.ts
@@ -20,11 +20,11 @@ export class CipherResponse extends CipherWithIds implements BaseResponse {
         this.object = 'item';
         this.build(o);
         if (o.attachments != null) {
-            this.attachments = o.attachments.map((a) => new AttachmentResponse(a));
+            this.attachments = o.attachments.map(a => new AttachmentResponse(a));
         }
         this.revisionDate = o.revisionDate;
         if (o.passwordHistory != null) {
-            this.passwordHistory = o.passwordHistory.map((h) => new PasswordHistoryResponse(h));
+            this.passwordHistory = o.passwordHistory.map(h => new PasswordHistoryResponse(h));
         }
         if (o.type === CipherType.Login && o.login != null) {
             this.login = new LoginResponse(o.login);

--- a/src/models/response/sendResponse.ts
+++ b/src/models/response/sendResponse.ts
@@ -92,7 +92,7 @@ export class SendResponse implements BaseResponse {
         }
         this.id = o.id;
         this.accessId = o.accessId;
-        this.accessUrl = (webVaultUrl ?? 'https://vault.bitwarden.com') + '/#/send/' + this.accessId + '/' + o.urlB64Key
+        this.accessUrl = (webVaultUrl ?? 'https://vault.bitwarden.com') + '/#/send/' + this.accessId + '/' + o.urlB64Key;
         this.name = o.name;
         this.notes = o.notes;
         this.key = Utils.fromBufferToB64(o.key);

--- a/src/program.ts
+++ b/src/program.ts
@@ -63,7 +63,7 @@ export class Program extends BaseProgram {
             process.env.BW_NOINTERACTION = 'true';
         });
 
-        program.on('option:session', (key) => {
+        program.on('option:session', key => {
             process.env.BW_SESSION = key;
         });
 
@@ -149,7 +149,7 @@ export class Program extends BaseProgram {
                 writeLn('    bw logout');
                 writeLn('', true);
             })
-            .action(async (cmd) => {
+            .action(async cmd => {
                 await this.exitIfNotAuthed();
                 const command = new LogoutCommand(this.main.authService, this.main.i18nService,
                     async () => await this.main.logout());
@@ -166,7 +166,7 @@ export class Program extends BaseProgram {
                 writeLn('    bw lock');
                 writeLn('', true);
             })
-            .action(async (cmd) => {
+            .action(async cmd => {
                 await this.exitIfNotAuthed();
                 const command = new LockCommand(this.main.vaultTimeoutService);
                 const response = await command.run(cmd);
@@ -221,7 +221,7 @@ export class Program extends BaseProgram {
                 writeLn('    bw sync --last');
                 writeLn('', true);
             })
-            .action(async (cmd) => {
+            .action(async cmd => {
                 await this.exitIfLocked();
                 const command = new SyncCommand(this.main.syncService);
                 const response = await command.run(cmd);
@@ -258,7 +258,7 @@ export class Program extends BaseProgram {
                 writeLn('    bw generate -p --words 5 --separator space');
                 writeLn('', true);
             })
-            .action(async (options) => {
+            .action(async options => {
                 const command = new GenerateCommand(this.main.passwordGenerationService);
                 const response = await command.run(options);
                 this.processResponse(response);

--- a/src/send.program.ts
+++ b/src/send.program.ts
@@ -116,7 +116,7 @@ export class SendProgram extends Program {
             .description('Get json templates for send objects', {
                 object: 'Valid objects are: send, send.text, send.file'
             })
-            .action(async (object) => {
+            .action(async object => {
                 const cmd = new GetCommand(this.main.cipherService, this.main.folderService,
                     this.main.collectionService, this.main.totpService, this.main.auditService, this.main.cryptoService,
                     this.main.userService, this.main.searchService, this.main.apiService, this.main.sendService,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export class CliUtils {
         }
 
         return new Promise<string>((resolve, reject) => {
-            fs.writeFile(p, data, 'utf8', (err) => {
+            fs.writeFile(p, data, 'utf8', err => {
                 if (err != null) {
                     reject('Cannot save file to ' + p);
                 }
@@ -143,7 +143,7 @@ export class CliUtils {
 
     static searchFolders(folders: FolderView[], search: string) {
         search = search.toLowerCase();
-        return folders.filter((f) => {
+        return folders.filter(f => {
             if (f.name != null && f.name.toLowerCase().indexOf(search) > -1) {
                 return true;
             }
@@ -153,7 +153,7 @@ export class CliUtils {
 
     static searchCollections(collections: CollectionView[], search: string) {
         search = search.toLowerCase();
-        return collections.filter((c) => {
+        return collections.filter(c => {
             if (c.name != null && c.name.toLowerCase().indexOf(search) > -1) {
                 return true;
             }
@@ -163,7 +163,7 @@ export class CliUtils {
 
     static searchOrganizations(organizations: Organization[], search: string) {
         search = search.toLowerCase();
-        return organizations.filter((o) => {
+        return organizations.filter(o => {
             if (o.name != null && o.name.toLowerCase().indexOf(search) > -1) {
                 return true;
             }

--- a/tslint.json
+++ b/tslint.json
@@ -85,6 +85,10 @@
     "arrow-parens": [
       true,
       "ban-single-arg-parens"
+    ],
+    "semicolon": [
+      true,
+      "always"
     ]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,17 +1,39 @@
 {
   "extends": "tslint:recommended",
   "rules": {
-    "align": [ true, "statements", "members" ],
+    "align": [
+      true,
+      "statements",
+      "members"
+    ],
     "ban-types": {
       "options": [
-        [ "Object", "Avoid using the `Object` type. Did you mean `object`?" ],
-        [ "Boolean", "Avoid using the `Boolean` type. Did you mean `boolean`?" ],
-        [ "Number", "Avoid using the `Number` type. Did you mean `number`?" ],
-        [ "String", "Avoid using the `String` type. Did you mean `string`?" ],
-        [ "Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?" ]
+        [
+          "Object",
+          "Avoid using the `Object` type. Did you mean `object`?"
+        ],
+        [
+          "Boolean",
+          "Avoid using the `Boolean` type. Did you mean `boolean`?"
+        ],
+        [
+          "Number",
+          "Avoid using the `Number` type. Did you mean `number`?"
+        ],
+        [
+          "String",
+          "Avoid using the `String` type. Did you mean `string`?"
+        ],
+        [
+          "Symbol",
+          "Avoid using the `Symbol` type. Did you mean `symbol`?"
+        ]
       ]
     },
-    "member-access": [ true, "no-public" ],
+    "member-access": [
+      true,
+      "no-public"
+    ],
     "member-ordering": [
       true,
       {
@@ -34,11 +56,20 @@
         ]
       }
     ],
-    "no-empty": [ true, "allow-empty-catch" ],
+    "no-empty": [
+      true,
+      "allow-empty-catch"
+    ],
     "object-literal-sort-keys": false,
-    "object-literal-shorthand": [ true, "never" ],
+    "object-literal-shorthand": [
+      true,
+      "never"
+    ],
     "prefer-for-of": false,
-    "quotemark": [ true, "single" ],
+    "quotemark": [
+      true,
+      "single"
+    ],
     "whitespace": [
       true,
       "check-branch",
@@ -50,6 +81,10 @@
       "check-type"
     ],
     "max-classes-per-file": false,
-    "ordered-imports": true
+    "ordered-imports": true,
+    "arrow-parens": [
+      true,
+      "ban-single-arg-parens"
+    ]
   }
 }


### PR DESCRIPTION
# Overview

It turns out there was a bug in out npm linter script which allowed LOTS of lint violations through. This PR fixes that error.

It also attempts to standardize a lint ruleset across bitwarden typescript repositories. We'll likely need a little more work on this front, though.

# Files Changed
* **package.json**: single quotes around globs are resolved by shell rather than npm.
* **tslint.conf**: 
  * ordered imports is a big hassle for our review process (I'm sure you don't like having to do this manual @cscharf). This gets one step toward removing that burden. Eventually we will want to investigate the groups option and standardize how we group our imports as well.
  * do not allow parenthesis in arrow functions with single parameters otherwise parenthesis are required.
  * semicolons are required everywhere

Other files changes are linter autofixes
  
  # Draft reason

I want to wait to merge this in until after #222 to avoid merge conflict there.