### PR TITLE
Limit export read to current user

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export class CliUtils {
         }
 
         return new Promise<string>((resolve, reject) => {
-            fs.writeFile(p, data, 'utf8', err => {
+            fs.writeFile(p, data, { encoding: 'utf8', mode: 0o600 }, err => {
                 if (err != null) {
                     reject('Cannot save file to ' + p);
                 }


### PR DESCRIPTION
# Overview

Linked to bitwarden/desktop/issues/705. The original complaint is on export in Desktop, but this behavior makes sense for all files and in CLI

The default should be for any file downloaded from Bitwarden to grant permissions to only the current User (permissions = 600).

# Files Changed

* **utils.ts**: This is the save method for all of CLI. We open up the saved file in user read/write only mode (600)

# Testing

Need to test for all downloaded items
* Attachments
* Exports
Need to test for all OS
* Windows
* Linux
* Mac

The expected behavior is that the logged in user can read and write to the downloaded file, but any other (non-super) user cannot.