### PR TITLE
Simplify send templates

### DIFF
--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -36,6 +36,8 @@ import { Response } from 'jslib/cli/models/response';
 import { MessageResponse } from 'jslib/cli/models/response/messageResponse';
 import { StringResponse } from 'jslib/cli/models/response/stringResponse';
 
+import { SendType } from 'jslib/enums/sendType';
+
 import { CipherResponse } from '../models/response/cipherResponse';
 import { CollectionResponse } from '../models/response/collectionResponse';
 import { FolderResponse } from '../models/response/folderResponse';
@@ -430,14 +432,11 @@ export class GetCommand extends DownloadCommand {
             case 'org-collection':
                 template = OrganizationCollectionRequest.template();
                 break;
-            case 'send':
-                template = SendResponse.template();
-                break;
             case 'send.text':
-                template = SendTextResponse.template();
+                template = SendResponse.template(SendType.Text);
                 break;
             case 'send.file':
-                template = SendFileResponse.template();
+                template = SendResponse.template(SendType.File);
                 break;
             default:
                 return Response.badRequest('Unknown template object.');

--- a/src/models/response/sendResponse.ts
+++ b/src/models/response/sendResponse.ts
@@ -14,7 +14,7 @@ const dateProperties: string[] = [Utils.nameOf<SendResponse>('deletionDate'), Ut
 
 export class SendResponse implements BaseResponse {
 
-    static template(sendType: SendType, deleteInDays = 7): SendResponse {
+    static template(sendType?: SendType, deleteInDays = 7): SendResponse {
         const req = new SendResponse();
         req.name = 'Send name';
         req.notes = 'Some notes about this send.';
@@ -22,7 +22,7 @@ export class SendResponse implements BaseResponse {
         req.text = sendType === SendType.Text ? SendTextResponse.template() : null;
         req.file = sendType === SendType.File ? SendFileResponse.template() : null;
         req.maxAccessCount = null;
-        req.deletionDate = this.getStandardDeletionDate(deleteInDays);
+        req.deletionDate = this.getStandardDeletionDate(deleteInDays); 
         req.expirationDate = null;
         req.password = null;
         req.disabled = false;

--- a/src/models/response/sendResponse.ts
+++ b/src/models/response/sendResponse.ts
@@ -14,13 +14,13 @@ const dateProperties: string[] = [Utils.nameOf<SendResponse>('deletionDate'), Ut
 
 export class SendResponse implements BaseResponse {
 
-    static template(deleteInDays = 7): SendResponse {
+    static template(sendType: SendType, deleteInDays = 7): SendResponse {
         const req = new SendResponse();
         req.name = 'Send name';
         req.notes = 'Some notes about this send.';
         req.type = SendType.Text;
-        req.text = null;
-        req.file = null;
+        req.text = sendType === SendType.Text ? SendTextResponse.template() : null;
+        req.file = sendType === SendType.File ? SendFileResponse.template() : null;
         req.maxAccessCount = null;
         req.deletionDate = this.getStandardDeletionDate(deleteInDays);
         req.expirationDate = null;

--- a/src/models/response/sendResponse.ts
+++ b/src/models/response/sendResponse.ts
@@ -22,7 +22,7 @@ export class SendResponse implements BaseResponse {
         req.text = sendType === SendType.Text ? SendTextResponse.template() : null;
         req.file = sendType === SendType.File ? SendFileResponse.template() : null;
         req.maxAccessCount = null;
-        req.deletionDate = this.getStandardDeletionDate(deleteInDays); 
+        req.deletionDate = this.getStandardDeletionDate(deleteInDays);
         req.expirationDate = null;
         req.password = null;
         req.disabled = false;

--- a/src/send.program.ts
+++ b/src/send.program.ts
@@ -251,7 +251,7 @@ export class SendProgram extends Program {
             sendText = SendTextResponse.template(data, options.hidden);
         }
 
-        const template = Utils.assign(SendResponse.template(options.deleteInDays), {
+        const template = Utils.assign(SendResponse.template(null, options.deleteInDays), {
             name: options.name ?? name,
             notes: options.notes,
             file: sendFile,


### PR DESCRIPTION
# Overview

@fschillingeriv pointed out that the `bw get template send` command is useless without a child `bw get template send.text/file` command inserted in the data field. He's totally right and it should be removed!

The new use of templates just creates the entire Send template structure for you based on the type of send you want to make.

# Files Changed
* **get.command.ts**: Remove send template and make send.text and send.file return the full send template
* **sendResponse.ts**: Populate data fields based on requested Send type
* **send.program.ts**: internally, don't specify a SendType since we set the file/text values manually 3  lines down

# Test Requirements

This should be pretty straightforward to test. 
* Need to make sure creation of sends both in for the "fast" `bw send` and "Advanced" `bw send create` work as expected.
* Also need to verify Templates exist and are valid for `bw get template send.text`/`bw get template send.file` and does not exist for `bw get template send`