### PR TITLE
Direct download for send

### DIFF
--- a/src/bw.ts
+++ b/src/bw.ts
@@ -143,7 +143,7 @@ export class Main {
             this.policyService);
         this.totpService = new TotpService(this.storageService, this.cryptoFunctionService);
         this.importService = new ImportService(this.cipherService, this.folderService, this.apiService,
-            this.i18nService, this.collectionService);
+            this.i18nService, this.collectionService, this.platformUtilsService);
         this.exportService = new ExportService(this.folderService, this.cipherService, this.apiService);
         this.authService = new AuthService(this.cryptoService, this.apiService, this.userService, this.tokenService,
             this.appIdService, this.i18nService, this.platformUtilsService, this.messagingService,
@@ -188,7 +188,7 @@ export class Main {
     }
 
     private async init() {
-        this.storageService.init();
+        await this.storageService.init();
         this.containerService.attachToWindow(global);
         await this.environmentService.setUrlsFromStorage();
         // Dev Server URLs. Comment out the line above.

--- a/src/commands/send/get.command.ts
+++ b/src/commands/send/get.command.ts
@@ -1,5 +1,6 @@
 import * as program from 'commander';
 
+import { ApiService } from 'jslib/abstractions/api.service';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { SearchService } from 'jslib/abstractions/search.service';
@@ -39,12 +40,6 @@ export class SendGetCommand extends DownloadCommand {
                 process.stdout.write(s.text.text);
                 return Response.success();
             };
-        }
-        if (options.file != null) {
-            filter = s => {
-                return filter(s) && s.file != null && s.file.url != null;
-            };
-            selector = async s => await this.saveAttachmentToFile(s.file.url, s.cryptoKey, s.file.fileName, options.output);
         }
 
         if (Array.isArray(sends)) {

--- a/src/models/response/sendFileResponse.ts
+++ b/src/models/response/sendFileResponse.ts
@@ -13,7 +13,6 @@ export class SendFileResponse {
         }
 
         view.id = file.id;
-        view.url = file.url;
         view.size = file.size;
         view.sizeName = file.sizeName;
         view.fileName = file.fileName;
@@ -21,7 +20,6 @@ export class SendFileResponse {
     }
 
     id: string;
-    url: string;
     size: string;
     sizeName: string;
     fileName: string;
@@ -31,7 +29,6 @@ export class SendFileResponse {
             return;
         }
         this.id = o.id;
-        this.url = o.url;
         this.size = o.size;
         this.sizeName = o.sizeName;
         this.fileName = o.fileName;

--- a/src/program.ts
+++ b/src/program.ts
@@ -153,7 +153,7 @@ export class Program extends BaseProgram {
                 await this.exitIfNotAuthed();
                 const command = new LogoutCommand(this.main.authService, this.main.i18nService,
                     async () => await this.main.logout());
-                const response = await command.run(cmd);
+                const response = await command.run();
                 this.processResponse(response);
             });
 

--- a/src/send.program.ts
+++ b/src/send.program.ts
@@ -132,7 +132,6 @@ export class SendProgram extends Program {
             .description('Get Sends owned by you.')
             .option('--output <output>', 'Output directory or filename for attachment.')
             .option('--text', 'Specifies to return the text content of a Send')
-            .option('--file', 'Specifies to return the file content of a Send. This can be paired with --output or --raw to output to stdout')
             .on('--help', () => {
                 writeLn('');
                 writeLn('  Id:');


### PR DESCRIPTION
# Overview

Similar PR to bitwarden/web#859. Implements download link requests. Also some changes due to jslib changes shared with bitwarden/directory-connector

# Files Changed
* **bw.ts/program.ts**: Changes due to bitwarden/directory-connector#95
* **get.command.ts/send.program.ts/sendFileResponse.ts**: Urls are no longer sent back with SendResponses so we can't use them download a Send file through a get command without requesting a download link. That would increment the AccessCount, which would be weird for an owner to do with explicitly running `bw receive`. The cleanest approach is to get rid of this functionality. This also matches current [web](bitwarden/web) behavior.
* **receive.command.ts**: Use the new api get download data endpoint to access a Send file

# Draft Reason
depends on bitwarden/jslib#288