### PR TITLE
Set time ms rather than hours

### DIFF
--- a/src/models/response/sendResponse.ts
+++ b/src/models/response/sendResponse.ts
@@ -63,7 +63,7 @@ export class SendResponse implements BaseResponse {
 
     private static getStandardDeletionDate(days: number) {
         const d = new Date();
-        d.setHours(d.getHours() + (days * 24));
+        d.setTime(d.getTime() + (days * 86400000)) // ms per day
         return d;
     }
 


### PR DESCRIPTION
# Overview

Currently we are not allowing deletion dates any less than 1 hour in the future, but that may be a legitimate use case.

# Files Changed

* **sendResponse.ts**: Set time based on ms rather than hours to allow for deletion dates less than 1 hour