### PR TITLE
Use send.bitwarden.com

### DIFF
--- a/src/commands/send/receive.command.ts
+++ b/src/commands/send/receive.command.ts
@@ -94,7 +94,7 @@ export class SendReceiveCommand extends DownloadCommand {
     }
 
     private getIdAndKey(url: URL): [string, string] {
-        const result = url.hash.split('/').slice(2);
+        const result = url.hash.slice(1).split('/').slice(-2);
         return [result[0], result[1]];
     }
 

--- a/src/models/response/sendResponse.ts
+++ b/src/models/response/sendResponse.ts
@@ -92,7 +92,7 @@ export class SendResponse implements BaseResponse {
         }
         this.id = o.id;
         this.accessId = o.accessId;
-        this.accessUrl = (webVaultUrl ?? 'https://vault.bitwarden.com') + '/#/send/' + this.accessId + '/' + o.urlB64Key;
+        this.accessUrl = (webVaultUrl ?? 'https://send.bitwarden.com') + '/#' + this.accessId + '/' + o.urlB64Key;
         this.name = o.name;
         this.notes = o.notes;
         this.key = Utils.fromBufferToB64(o.key);

--- a/src/models/response/sendResponse.ts
+++ b/src/models/response/sendResponse.ts
@@ -63,7 +63,7 @@ export class SendResponse implements BaseResponse {
 
     private static getStandardDeletionDate(days: number) {
         const d = new Date();
-        d.setTime(d.getTime() + (days * 86400000)) // ms per day
+        d.setTime(d.getTime() + (days * 86400000)); // ms per day
         return d;
     }
 
@@ -92,7 +92,13 @@ export class SendResponse implements BaseResponse {
         }
         this.id = o.id;
         this.accessId = o.accessId;
-        this.accessUrl = (webVaultUrl ?? 'https://send.bitwarden.com') + '/#' + this.accessId + '/' + o.urlB64Key;
+        let sendLinkBaseUrl = webVaultUrl;
+        if (sendLinkBaseUrl == null) {
+            sendLinkBaseUrl = 'https://send.bitwarden.com/#';
+        } else {
+            sendLinkBaseUrl += '/#/send';
+        }
+        this.accessUrl = sendLinkBaseUrl + '/' + this.accessId + '/' + o.urlB64Key;
         this.name = o.name;
         this.notes = o.notes;
         this.key = Utils.fromBufferToB64(o.key);

--- a/src/models/response/sendResponse.ts
+++ b/src/models/response/sendResponse.ts
@@ -96,9 +96,9 @@ export class SendResponse implements BaseResponse {
         if (sendLinkBaseUrl == null) {
             sendLinkBaseUrl = 'https://send.bitwarden.com/#';
         } else {
-            sendLinkBaseUrl += '/#/send';
+            sendLinkBaseUrl += '/#/send/';
         }
-        this.accessUrl = sendLinkBaseUrl + '/' + this.accessId + '/' + o.urlB64Key;
+        this.accessUrl = sendLinkBaseUrl + this.accessId + '/' + o.urlB64Key;
         this.name = o.name;
         this.notes = o.notes;
         this.key = Utils.fromBufferToB64(o.key);


### PR DESCRIPTION
still need compatibiltiy with /#/send/id/key, but adding on
compability with #id/key

works with URLs of type `vault.bitwarden.com/#/send/id/key` and `send.bitwarden.com/#id/key`