### PR TITLE
Add `bw get notes <id>` command

### DIFF
--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -84,6 +84,8 @@ export class GetCommand extends DownloadCommand {
                 return await this.getUri(id);
             case 'totp':
                 return await this.getTotp(id);
+            case 'notes':
+                return await this.getNotes(id);
             case 'exposed':
                 return await this.getExposed(id);
             case 'attachment':
@@ -238,6 +240,22 @@ export class GetCommand extends DownloadCommand {
         }
 
         const res = new StringResponse(totp);
+        return Response.success(res);
+    }
+
+    private async getNotes(id: string) {
+        const cipherResponse = await this.getCipher(id,
+            c => !Utils.isNullOrWhitespace(c.notes));
+        if (!cipherResponse.success) {
+            return cipherResponse;
+        }
+
+        const cipher = cipherResponse.data as CipherResponse;
+        if (Utils.isNullOrWhitespace(cipher.notes)) {
+            return Response.error('No notes available for this item.');
+        }
+
+        const res = new StringResponse(cipher.notes);
         return Response.success(res);
     }
 

--- a/src/vault.program.ts
+++ b/src/vault.program.ts
@@ -88,6 +88,7 @@ export class VaultProgram extends Program {
                 writeLn('    password');
                 writeLn('    uri');
                 writeLn('    totp');
+                writeLn('    notes');
                 writeLn('    exposed');
                 writeLn('    attachment');
                 writeLn('    folder');
@@ -110,6 +111,7 @@ export class VaultProgram extends Program {
                 writeLn('    bw get item 99ee88d2-6046-4ea7-92c2-acac464b1412');
                 writeLn('    bw get password https://google.com');
                 writeLn('    bw get totp google.com');
+                writeLn('    bw get notes google.com');
                 writeLn('    bw get exposed yahoo.com');
                 writeLn('    bw get attachment b857igwl1dzrs2 --itemid 99ee88d2-6046-4ea7-92c2-acac464b1412 ' +
                     '--output ./photo.jpg');


### PR DESCRIPTION
Rationale: the notes object is a freeform plain-text field that's
prominently displayed in Web Vault. It is also useful for the CLI users
as discussed before in issues #81 and #196. I have some use cases
planned myself.

I was rather surprised this wasn't supported already, but the
implementation is simple and cannot really break any existing
functionality so here it is.