### PR TITLE
Add api parsing special case for send.bitwarden.com

### DIFF
--- a/src/commands/send/receive.command.ts
+++ b/src/commands/send/receive.command.ts
@@ -99,7 +99,9 @@ export class SendReceiveCommand extends DownloadCommand {
     }
 
     private getApiUrl(url: URL) {
-        if (url.origin === this.apiService.apiBaseUrl) {
+        if (url.origin === 'https://send.bitwarden.com') {
+            return 'https://vault.bitwarden.com/api';
+        } else if (url.origin === this.apiService.apiBaseUrl) {
             return url.origin;
         } else if (this.platformUtilsService.isDev() && url.origin === this.environmentService.getWebVaultUrl()) {
             return this.apiService.apiBaseUrl;


### PR DESCRIPTION
# Overview

In the scramble to support `send.bitwarden.com` I missed api parsing. Oops. This fixes this fixes CLI `bw receive` commands from the prod instance failing due to misinterpreting the api endpoint.

# Files changed
* **send/receive.command.ts**: Api Parsing special case for `send.bitwarden.com` to point to `vault.bitwarden.com/api` as it should.