### PR TITLE
Creating issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+Please do not submit feature requests. The [Community Forums][1] has a
+section for submitting, voting for, and discussing product feature requests.
+[1]: https://community.bitwarden.com
+-->
+
+## Describe the Bug
+
+<!-- Comment:
+A clear and concise description of what the bug is.
+-->
+
+## Steps To Reproduce
+
+<!-- Comment:
+How can we reproduce the behavior:
+-->
+
+1. Launch using command, '...'
+2. Copy value '....'
+3. Pipe to '....'
+4. Run the following command, '...'
+
+## Expected Result
+
+<!-- Comment:
+A clear and concise description of what you expected to happen.
+-->
+
+## Actual Result
+
+<!-- Comment:
+A clear and concise description of what is happening.
+-->
+
+## Screenshots or Videos
+
+<!-- Comment:
+If applicable, add screenshots and/or a short video to help explain your problem.
+-->
+
+## Environment
+
+- Operating system: [e.g. Windows 10, macOS BigSur, Ubuntu]
+- Shell: [e.g. bash, zsh, PowerShell]
+- Build Version (run `bw --version`): [e.g. 1.15.1]
+
+## Additional Context
+
+<!-- Comment:
+Add any other context about the problem here.
+-->


### PR DESCRIPTION
Creating issue template similar to what we have in other repos. Currently there's nothing letting posters know how to structure issue reports OR that feature requests should be posted in the [Community Forums](https://community.bitwarden.com) and not in GitHub.