### PR TITLE
Add hideEmail to sendResponse model and template

### DIFF
--- a/src/models/response/sendResponse.ts
+++ b/src/models/response/sendResponse.ts
@@ -26,6 +26,7 @@ export class SendResponse implements BaseResponse {
         req.expirationDate = null;
         req.password = null;
         req.disabled = false;
+        req.hideEmail = false;
         return req;
     }
 
@@ -49,6 +50,7 @@ export class SendResponse implements BaseResponse {
         view.expirationDate = send.expirationDate;
         view.password = send.password;
         view.disabled = send.disabled;
+        view.hideEmail = send.hideEmail;
         return view;
     }
 
@@ -85,6 +87,7 @@ export class SendResponse implements BaseResponse {
     password: string;
     passwordSet: boolean;
     disabled: boolean;
+    hideEmail: boolean;
 
     constructor(o?: SendView, webVaultUrl?: string) {
         if (o == null) {
@@ -110,6 +113,7 @@ export class SendResponse implements BaseResponse {
         this.expirationDate = o.expirationDate;
         this.passwordSet = o.password != null;
         this.disabled = o.disabled;
+        this.hideEmail = o.hideEmail;
 
         if (o.type === SendType.Text && o.text != null) {
             this.text = new SendTextResponse(o.text);


### PR DESCRIPTION
## Objective
CLI implementation of "hide email address in Sends" feature: https://github.com/bitwarden/web/pull/895

## Code changes
* add `hideEmail` to Send template
* add `hideEmail` to the CLI-specific `sendResponse` object

Other implementation notes:
* All other model changes should already be handled through jslib, which has already been updated. 
* I did not add any new option flag because it's an advanced option, which only appear to be set via json.
* `SendAccessResponse` does not contain a `creatorIdentifier` - in other words, `bw send receive <url>` does not usually show the creator's email - so no changes are needed there. I also assume that no warning banner is required in this instance, given that CLI users are unable to check the creator's email currently.