### PR TITLE
Fix snap test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
             Throw "Version test failed."
           }
         env:
-          BITWARDENCLI_APPDATA_DIR: "/home/runner/snap/bw/x1"
+          BITWARDENCLI_APPDATA_DIR: "/home/runner/snap/bw/x1/.config/Bitwarden CLI"
 
       - name: Cleanup Test & Update Snap for Publish
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,8 +223,8 @@ jobs:
           if($testVersion -ne $env:PACKAGE_VERSION) {
             Throw "Version test failed."
           }
-        #env:
-        #  BITWARDENCLI_APPDATA_DIR: "snap/bw/x1"
+        env:
+          BITWARDENCLI_APPDATA_DIR: "/home/runner/snap/bw/x1"
 
       - name: Cleanup Test & Update Snap for Publish
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
     name: Build Snap
     runs-on: ubuntu-latest
     needs: cli
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/fix-snap-test'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,6 +223,8 @@ jobs:
           if($testVersion -ne $env:PACKAGE_VERSION) {
             Throw "Version test failed."
           }
+        env:
+          BITWARDENCLI_APPDATA_DIR: "~/snap/bw/x1"
 
       - name: Cleanup Test & Update Snap for Publish
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
           path: ./dist/bw-macos-sha256-${{ env.PACKAGE_VERSION }}.txt
 
       - name: Publish linux zip to GitHub
-        #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with:
           name: bw-linux-${{ env.PACKAGE_VERSION }}.zip
@@ -171,7 +171,7 @@ jobs:
     name: Build Snap
     runs-on: ubuntu-latest
     needs: cli
-    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,8 +223,8 @@ jobs:
           if($testVersion -ne $env:PACKAGE_VERSION) {
             Throw "Version test failed."
           }
-        env:
-          BITWARDENCLI_APPDATA_DIR: "~/snap/bw/x1"
+        #env:
+        #  BITWARDENCLI_APPDATA_DIR: "snap/bw/x1"
 
       - name: Cleanup Test & Update Snap for Publish
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
           path: ./dist/bw-macos-sha256-${{ env.PACKAGE_VERSION }}.txt
 
       - name: Publish linux zip to GitHub
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+        #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with:
           name: bw-linux-${{ env.PACKAGE_VERSION }}.zip
@@ -171,7 +171,7 @@ jobs:
     name: Build Snap
     runs-on: ubuntu-latest
     needs: cli
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc' || github.ref == 'refs/heads/fix-snap-test'
+    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
There is a weird and unknown bug with the data config path with the snap test. I tested this locally with snap and it worked like it is supposed to (writing to `~/snap/bw/x1`), but this isn't the case with the latest merge to master. This uses an env var to override it to the correct data directory

##
- .github/workflows/build.yml