### PR TITLE
Fix --fullObject support for send create command

### DIFF
--- a/src/send.program.ts
+++ b/src/send.program.ts
@@ -170,15 +170,23 @@ export class SendProgram extends Program {
             .option('--text <text>', 'text to Send. Can also be specified in parent\'s JSON.')
             .option('--hidden', 'text hidden flag. Valid only with the --text option.')
             .option('--password <password>', 'optional password to access this Send. Can also be specified in JSON')
-            .option('--fullObject', 'Specifies that the full Send object should be returned rather than just the access url.')
             .on('--help', () => {
                 writeLn('');
                 writeLn('Note:');
                 writeLn('  Options specified in JSON take precedence over command options');
                 writeLn('', true);
             })
-            .action(async (encodedJson: string, options: program.OptionValues) => {
-                const response = await this.runCreate(encodedJson, options);
+            .action(async (encodedJson: string, options: program.OptionValues, args: { parent: program.Command }) => {
+                // Work-around to support `--fullObject` option for `send create --fullObject`
+                // Calling `option('--fullObject', ...)` above won't work due to Commander doesn't like same option
+                // to be defind on both parent-command and sub-command
+                const { fullObject = false } = args.parent.opts();
+                const mergedOptions = {
+                    ...options,
+                    fullObject
+                };
+
+                const response = await this.runCreate(encodedJson, mergedOptions);
                 this.processResponse(response);
             });
     }


### PR DESCRIPTION
Fixes #268 

As discussed in the issue, this is not really an elegant solution due to some limitations of https://github.com/tj/commander.js. I create this PR anyway but @MGibson1 if you're not happy with it, feel free to close it.

## Test

Command:

```shell
node ./build/bw.js send template send.text | jq '.name="Foo" | .text.text="Secret"' | node ./build/bw.js encode | node ./build/bw.js send create --fullObject
```

Response:

```json
{"object":"send","id":"xxx","accessId":"xxx","accessUrl":"https://send.bitwarden.com/#xxx/yyy","name":"Foo","notes":"Some notes about this send.","key":"kkk","type":0,"maxAccessCount":null,"accessCount":0,"revisionDate":"2021-04-08T08:49:54.749Z","deletionDate":"2021-04-15T08:49:52.316Z","expirationDate":null,"passwordSet":false,"disabled":false,"hideEmail":false,"text":{"text":"Secret","hidden":false}}
```