### PR TITLE
If error is of unkown type, create and error response from it.

### DIFF
--- a/src/commands/send/receive.command.ts
+++ b/src/commands/send/receive.command.ts
@@ -142,12 +142,9 @@ export class SendReceiveCommand extends DownloadCommand {
                     return Response.badRequest('Bad Request');
                 } else if (e.statusCode === 404) {
                     return Response.notFound();
-                } else {
-                    return Response.error(e);
                 }
-            } else {
-                return Response.error(e);
             }
+            return Response.error(e);
         }
     }
 }

--- a/src/commands/send/receive.command.ts
+++ b/src/commands/send/receive.command.ts
@@ -145,6 +145,8 @@ export class SendReceiveCommand extends DownloadCommand {
                 } else {
                     return Response.error(e);
                 }
+            } else {
+                return Response.error(e);
             }
         }
     }


### PR DESCRIPTION
# Overview

We found an issue with receive where internal node errors (fetching from a self-signed cert host) threw an error which was eaten by `receive` error handling.

This PR throws if an exception is thrown during receive which results in an unknown, irrecoverable type.