### PR TITLE
Use Get command for final return value of edit

### DIFF
--- a/src/commands/send/edit.command.ts
+++ b/src/commands/send/edit.command.ts
@@ -1,5 +1,6 @@
 import * as program from 'commander';
 
+import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { SendService } from 'jslib/abstractions/send.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
@@ -9,9 +10,11 @@ import { SendType } from 'jslib/enums/sendType';
 import { SendResponse } from '../../models/response/sendResponse';
 
 import { CliUtils } from '../../utils';
+import { SendGetCommand } from './get.command';
 
 export class SendEditCommand {
-    constructor(private sendService: SendService, private userService: UserService) { }
+    constructor(private sendService: SendService, private userService: UserService,
+        private getCommand: SendGetCommand) { }
 
     async run(encodedJson: string, options: program.OptionValues): Promise<Response> {
         if (encodedJson == null || encodedJson === '') {
@@ -64,12 +67,10 @@ export class SendEditCommand {
             encSend.expirationDate = sendView.expirationDate;
 
             await this.sendService.saveWithServer([encSend, encFileData]);
-            const updatedSend = await this.sendService.get(send.id);
-            const decSend = await updatedSend.decrypt();
-            const res = new SendResponse(decSend);
-            return Response.success(res);
         } catch (e) {
             return Response.error(e);
         }
+
+        return await this.getCommand.run(send.id, {});
     }
 }

--- a/src/send.program.ts
+++ b/src/send.program.ts
@@ -198,7 +198,9 @@ export class SendProgram extends Program {
             })
             .action(async (encodedJson: string, options: program.OptionValues) => {
                 await this.exitIfLocked();
-                const cmd = new SendEditCommand(this.main.sendService, this.main.userService);
+                const getCmd = new SendGetCommand(this.main.sendService, this.main.environmentService,
+                    this.main.searchService, this.main.cryptoService);
+                const cmd = new SendEditCommand(this.main.sendService, this.main.userService, getCmd);
                 const response = await cmd.run(encodedJson, options);
                 this.processResponse(response);
             });


### PR DESCRIPTION
# Overview

There are one or two eccentricities to building a valid Send object that are implemented in the Send Get command, but not Edit. This PR uses Get as the final step of Edit in order to ensure the final Send object is built properly.

Because CLI currently handles DI itself, there is not potential of weird circular dependencies with commands depending on each other.

# Files Changed

* **edit.command**: require a get command to be utilized after update.
* **send.program**: pass in a Get command object