### PR TITLE
Specify api url in Send file download request

### DIFF
--- a/src/commands/send/receive.command.ts
+++ b/src/commands/send/receive.command.ts
@@ -86,7 +86,7 @@ export class SendReceiveCommand extends DownloadCommand {
                 process.stdout.write(response?.text?.text);
                 return Response.success();
             case SendType.File:
-                const downloadData = await this.apiService.getSendFileDownloadData(response, this.sendAccessRequest);
+                const downloadData = await this.apiService.getSendFileDownloadData(response, this.sendAccessRequest, apiUrl);
                 return await this.saveAttachmentToFile(downloadData.url, this.decKey, response?.file?.fileName, options.output);
             default:
                 return Response.success(new SendAccessResponse(response));


### PR DESCRIPTION
# Overview 

Depends on bitwarden/jslib#348. Allows for receiving of Sends from different Bitwarden servers than the one configured for the CLI