### PR TITLE
Get Attachment Download url from server

### DIFF
--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -32,6 +32,7 @@ import { FolderView } from 'jslib/models/view/folderView';
 
 import { EncString } from 'jslib/models/domain/encString';
 
+import { ErrorResponse } from 'jslib/models/response/errorResponse';
 import { Response } from 'jslib/cli/models/response';
 import { StringResponse } from 'jslib/cli/models/response/stringResponse';
 
@@ -287,9 +288,23 @@ export class GetCommand extends DownloadCommand {
             }
         }
 
+        let url: string;
+        try {
+            const attachmentDownloadResponse = await this.apiService.getAttachmentData(cipher.id, attachments[0].id);
+            url = attachmentDownloadResponse.url;
+        } catch (e) {
+            if (e instanceof ErrorResponse && (e as ErrorResponse).statusCode === 404) {
+                url = attachments[0].url;
+            } else if (e instanceof ErrorResponse) {
+                throw new Error((e as ErrorResponse).getSingleMessage());
+            } else {
+                throw e;
+            }
+        }
+
         const key = attachments[0].key != null ? attachments[0].key :
             await this.cryptoService.getOrgKey(cipher.organizationId);
-        return await this.saveAttachmentToFile(attachments[0].url, key, attachments[0].fileName, options.output);
+        return await this.saveAttachmentToFile(url, key, attachments[0].fileName, options.output);
     }
 
     private async getFolder(id: string) {


### PR DESCRIPTION
# Overview

Fix for: https://app.asana.com/0/0/1200170130625742/f -- CLI not downloading new attachment uploads
Grab attachment download data from server to accommodate attachments uploaded to `attachments-v2` container.

# Files Changed
* **get.command.ts**: Grab attachment data, fallback to the initial url retrieved with the attachment. This is the same method used in `attachment.component.ts` in jslib.
