### PR TITLE
Add maxAccessCount to send command

### DIFF
--- a/src/commands/send/create.command.ts
+++ b/src/commands/send/create.command.ts
@@ -60,8 +60,10 @@ export class SendCreateCommand {
         const text = req.text?.text ?? options.text;
         const hidden = req.text?.hidden ?? options.hidden;
         const password = req.password ?? options.password;
+        const maxAccessCount = req.maxAccessCount ?? options.maxAccessCount;
 
         req.key = null;
+        req.maxAccessCount = maxAccessCount;
 
         switch (req.type) {
             case SendType.File:

--- a/src/send.program.ts
+++ b/src/send.program.ts
@@ -47,6 +47,7 @@ export class SendProgram extends Program {
             })
             .option('-f, --file', 'Specifies that <data> is a filepath')
             .option('-d, --deleteInDays <days>', 'The number of days in the future to set deletion date, defaults to 7', '7')
+            .option('-a, --maxAccessCount <amount>', 'The amount of max possible accesses.')
             .option('--hidden', 'Hide <data> in web by default. Valid only if --file is not set.')
             .option('-n, --name <name>', 'The name of the Send. Defaults to a guid for text Sends and the filename for files.')
             .option('--notes <notes>', 'Notes to add to the Send.')


### PR DESCRIPTION
I was missing the option of setting the limitation of maximum accesses for the send command.
So I just implemented it.

**for text**
```
$ node ./build/bw.js send -n limit-access-test -a 1 "i like trains"

$ node ./build/bw.js send --name limit-access-test --maxAccessCount 1 "i like trains"
```

**works for files aswell**
```
$ node ./build/bw.js send -n limit-access-test -a 1 -f TRAINS.md

$ node ./build/bw.js send --name limit-access-test --maxAccessCount 1 --file TRAINS.md
```