### PR TITLE
Replace cipher results with filtered results

### DIFF
--- a/src/commands/get.command.ts
+++ b/src/commands/get.command.ts
@@ -133,9 +133,9 @@ export class GetCommand extends DownloadCommand {
         }
         if (Array.isArray(decCipher)) {
             if (filter != null) {
-                const filteredCiphers = decCipher.filter(filter);
-                if (filteredCiphers.length === 1) {
-                    decCipher = filteredCiphers[0];
+                decCipher = decCipher.filter(filter);
+                if (decCipher.length === 1) {
+                    decCipher = decCipher[0];
                 }
             }
             if (Array.isArray(decCipher)) {


### PR DESCRIPTION
# Overview

`bw get` commands which pull field values filter down to ciphers which have that field populated. If multiple results are returned, we are currently listing all ciphers matching the search term rather than just those matching the search term and filtering criteria.

This PR alters behavior such that only ciphers both matching the search term and the filtering criteria are returned in the multipleResponse error.

# Files changed
* **get.command**: fix defect.