### PR TITLE
Adjust node version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We provide detailed documentation and examples for using the CLI in our help cen
 
 **Requirements**
 
-- [Node.js](https://nodejs.org/)
+- [Node.js](https://nodejs.org) v14.17 or greater
 
 **Run the app**
 


### PR DESCRIPTION
With @Hinton bumping node to 14 earlier today, I've adjusted the README to show the need for Node 14.17 (LTS)