### PR TITLE
Use same export filename format as other clients

### DIFF
--- a/src/commands/export.command.ts
+++ b/src/commands/export.command.ts
@@ -5,7 +5,6 @@ import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { ExportService } from 'jslib/abstractions/export.service';
 
 import { Response } from 'jslib/cli/models/response';
-import { MessageResponse } from 'jslib/cli/models/response/messageResponse';
 
 import { CliUtils } from '../utils';
 
@@ -54,10 +53,22 @@ export class ExportCommand {
 
     async saveFile(exportContent: string, options: program.OptionValues, format: string): Promise<Response> {
         try {
-            const fileName = this.exportService.getFileName(options.organizationid != null ? 'org' : null, format);
+            const fileName = this.getFileName(format, options.organizationid != null ? 'org' : null);
             return await CliUtils.saveResultToFile(exportContent, options.output, fileName);
         } catch (e) {
             return Response.error(e.toString());
         }
+    }
+
+    private getFileName(format: string, prefix?: string) {
+        if (format === 'encrypted_json') {
+            if (prefix == null) {
+                prefix = 'encrypted';
+            } else {
+                prefix = 'encrypted_' + prefix;
+            }
+            format = 'json';
+        }
+        return this.exportService.getFileName(prefix, format);
     }
 }


### PR DESCRIPTION
## Objective

Fix the following defect:

> When exporting an encrypted JSON, the string passed from the --format option becomes the file name extension. For example, here's the command and terminal output I received when trying to create an encrypted export:
>
> ~/Bitwarden/cli/build on branch master > node ./bw.js export (redactedPassword) --format encrypted_json
Saved /Users/(username)/Bitwarden/cli/build/bitwarden_export_20210526083638.encrypted_json
>
> Although the file can be imported successfully in Bitwarden, this seems a bit odd since the file can't be opened with a different program without manually changing the file extension.

Relatedly, the CLI does not use the `encrypted` prefix in the filename of the exported file like other Angular clients do. All clients should ideally use the same naming structure.

## Code changes
Copy and adapt the [getFileName method from BaseExportComponent](https://github.com/bitwarden/jslib/blob/6fbe33043b4994b1f01022b62c19aa10227f56b2/src/angular/components/export.component.ts#L88). This is a little duplicative, but moving this into the ExportService and then refactoring all the clients really seemed like overkill for a fairly minor change.