### PR TITLE
[PoC] User Password Access Report

### DIFF
--- a/src/commands/passwordaccessreport.command.ts
+++ b/src/commands/passwordaccessreport.command.ts
@@ -1,0 +1,173 @@
+import * as program from 'commander';
+import { ApiService, CipherService, CollectionService, UserService } from 'jslib/abstractions';
+import { ExportService } from 'jslib/abstractions/export.service';
+import { Response } from 'jslib/cli/models/response';
+import { EventType } from 'jslib/enums/eventType';
+import { Utils } from 'jslib/misc/utils';
+import { Organization } from 'jslib/models/domain/organization';
+import { ListResponse } from 'jslib/models/response';
+import { EventResponse } from 'jslib/models/response/eventResponse';
+import * as papa from 'papaparse';
+import { OrganizationUserResponse } from '../models/response/organizationUserResponse';
+import { CliUtils } from '../utils';
+
+export class PasswordAccessReportCommand {
+    constructor(private exportService: ExportService,
+                private userService: UserService,
+                private apiService: ApiService,
+                private cipherService: CipherService,
+                private collectionService: CollectionService,
+    ) {
+    }
+
+    async run(username: string, from: string, to: string, options: program.OptionValues): Promise<Response> {
+
+        const organization = await this.getOrganization(options);
+        const members = await this.listOrganizationMembers(organization);
+        const user = members.filter(member => member.email === username)?.[0];
+        if (user === undefined) {
+            return Response.badRequest('User does not exists for Organization!');
+        }
+
+        try {
+            const userEvents = await this.getUserEvents(organization, user.id, from, to);
+            const ciphersDecrypted = (await this.cipherService.getAllDecrypted())
+                // filter unused ciphers
+                .filter(cad => userEvents.map(fe => fe.cipherId).includes(cad.id));
+            // latest modified cipher event for each cipher
+            const lastModifiedCipherEvents = await Promise.all(ciphersDecrypted.map(async cipherDecrypted => {
+                const lastModifiedEvent = await this.getCipherLastModifiedEvent(cipherDecrypted.id, from, to);
+                const latestEditUser = members.find(m => m.userId === lastModifiedEvent?.actingUserId);
+                const lastModified = {
+                    'username': latestEditUser?.name,
+                    'email': latestEditUser?.email,
+                    'date': lastModifiedEvent.date,
+                    'type': lastModifiedEvent.type.toString(),
+                    'type_name': EventType[lastModifiedEvent.type],
+                };
+
+                return [cipherDecrypted.id, lastModified] as [string, { date: string; type_name: string; type: string; email: string; username: string }];
+            }));
+            const cipherEvents = new Map(lastModifiedCipherEvents);
+            const collectionAllDecrypted = await this.collectionService.getAllDecrypted();
+            const userPasswordAccessEvents = userEvents.map(e => {
+                const cipherEvent = ciphersDecrypted.find(cd => cd.id === e.cipherId);
+                const collectionEvent = collectionAllDecrypted.filter(cd => cipherEvent.collectionIds.includes(cd.id));
+                const lastModifiedEvent = cipherEvents.get(cipherEvent.id);
+
+                return {
+                    'name': cipherEvent.name,
+                    'date': e.date,
+                    'type': e.type.toString(),
+                    'type_name': EventType[e.type],
+                    'collections': collectionEvent.map(ce => ce.name).join(','),
+                    'uri': cipherEvent.login.uri,
+                    'last_modified_username': lastModifiedEvent.username,
+                    'last_modified_email': lastModifiedEvent.email,
+                    'last_modified_date': lastModifiedEvent.date,
+                    'last_modified_type_name': lastModifiedEvent.type_name,
+                    'last_modified_type': lastModifiedEvent.type,
+                };
+            });
+            const format = options.format !== 'json' ? 'csv' : 'json';
+
+            let exportContent;
+            if (format === 'csv') {
+                exportContent = papa.unparse(userPasswordAccessEvents);
+            } else {
+                exportContent = JSON.stringify(userPasswordAccessEvents);
+            }
+
+            return await this.saveFile(exportContent, options, format);
+        } catch (e) {
+            return Response.badRequest(e);
+        }
+    }
+
+    private async getUserEvents(organization: Organization, userId: string, from: string, to: string): Promise<EventResponse[]> {
+        const eventsPageList = [];
+        let continuationToken = null;
+        do {
+            const eventsPage: ListResponse<EventResponse> = await this.apiService.getEventsOrganizationUser(organization.id, userId, from, to, continuationToken);
+            eventsPageList.push(eventsPage.data);
+            continuationToken = eventsPage.continuationToken;
+        }
+        while (continuationToken);
+
+        const eventTypes = [
+            EventType.Cipher_Created,
+            EventType.Cipher_ClientToggledPasswordVisible,
+            EventType.Cipher_ClientToggledHiddenFieldVisible,
+            EventType.Cipher_ClientCopiedPassword,
+            EventType.Cipher_ClientCopiedHiddenField,
+        ];
+        const filteredEventsMap = new Map(
+            ([] as EventResponse[]).concat(...eventsPageList)
+                .reverse()
+                .filter(event => eventTypes.includes(event.type))
+                .map(key => [key.cipherId, key] as [string, EventResponse]));
+
+        return Array.from(filteredEventsMap, ([k, v]) => v);
+    }
+
+    private async getCipherLastModifiedEvent(cipherId: string, from: string, to: string): Promise<EventResponse> {
+        const eventsPageList = [];
+        let continuationToken = null;
+        do {
+            const eventsPage: ListResponse<EventResponse> = await this.apiService.getEventsCipher(cipherId, from, null, continuationToken);
+            eventsPageList.push(eventsPage.data);
+            continuationToken = eventsPage.continuationToken;
+        }
+        while (continuationToken);
+
+        const allEvents = await Promise.all(eventsPageList);
+        return ([] as EventResponse[]).concat(...allEvents)
+            .filter(event => [
+                    EventType.Cipher_Created,
+                    EventType.Cipher_Updated,
+                ].includes(event.type)
+            ).reverse()[0];
+    }
+
+    private async saveFile(exportContent: string, options: program.OptionValues, format: string): Promise<Response> {
+        try {
+            const fileName = this.exportService.getFileName(options.organizationid != null ? 'user_last_password_access' : null, format);
+            return await CliUtils.saveResultToFile(exportContent, options.output, fileName);
+        } catch (e) {
+            return Response.error(e.toString());
+        }
+    }
+
+    private async getOrganization(options: program.OptionValues): Promise<Organization> {
+        if (options.organizationid == null || options.organizationid === '') {
+            throw new Error('--organizationid <organizationid> required.');
+        }
+        if (!Utils.isGuid(options.organizationid)) {
+            throw new Error('`' + options.organizationid + '` is not a GUID.');
+        }
+        const organization = await this.userService.getOrganization(options.organizationid);
+        if (organization == null) {
+            throw new Error('Organization not found.');
+        }
+        return organization;
+    }
+
+    private async listOrganizationMembers(organization: Organization): Promise<OrganizationUserResponse[]> {
+        try {
+            const response = await this.apiService.getOrganizationUsers(organization.id);
+            return response.data.map(r => {
+                const u = new OrganizationUserResponse();
+                u.email = r.email;
+                u.name = r.name;
+                u.id = r.id;
+                u.status = r.status;
+                u.type = r.type;
+                u.twoFactorEnabled = r.twoFactorEnabled;
+                u.userId = r.userId;
+                return u;
+            });
+        } catch (e) {
+            throw e;
+        }
+    }
+}

--- a/src/models/response/organizationUserResponse.ts
+++ b/src/models/response/organizationUserResponse.ts
@@ -11,6 +11,7 @@ export class OrganizationUserResponse implements BaseResponse {
     status: OrganizationUserStatusType;
     type: OrganizationUserType;
     twoFactorEnabled: boolean;
+    userId: string;
 
     constructor() {
         this.object = 'org-member';

--- a/src/vault.program.ts
+++ b/src/vault.program.ts
@@ -3,6 +3,7 @@ import * as program from 'commander';
 
 import { Main } from './bw';
 
+import { PasswordAccessReportCommand } from './commands/passwordaccessreport.command';
 import { ConfirmCommand } from './commands/confirm.command';
 import { CreateCommand } from './commands/create.command';
 import { DeleteCommand } from './commands/delete.command';
@@ -366,5 +367,43 @@ export class VaultProgram extends Program {
                 this.processResponse(response);
             });
 
+        program
+            .command('par <email> <from> <to>')
+            .description('Export password access report to a CSV or JSON file.')
+            .option('--output <output>', 'Output directory or filename.')
+            .option('--format <format>', 'Export file format.')
+            .option('--organizationid <organizationid>', 'Organization id for an organization.')
+            .on('--help', () => {
+                writeLn('\n  Notes:');
+                writeLn('');
+                writeLn('    Valid formats are `csv`, `json`. Default format is `csv`.');
+                writeLn('');
+                writeLn('    If --raw option is specified and no output filename or directory is given, the');
+                writeLn('    result is written to stdout.');
+                writeLn('');
+                writeLn('  Examples:');
+                writeLn('');
+                writeLn('    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd');
+                writeLn('    bw par --organizationid example-org-id firstname.lastname@example.com 2021-01-01 2021-07');
+                writeLn('    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --raw');
+                writeLn('    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --raw --format csv');
+                writeLn('    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --format json');
+                writeLn('    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --output report.csv');
+                writeLn('    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --output report.json --format json');
+                writeLn('', true);
+            })
+            .action(async (email, from, to, options) => {
+                await this.exitIfLocked();
+                const command = new PasswordAccessReportCommand(
+                    this.main.exportService,
+                    this.main.userService,
+                    this.main.apiService,
+                    this.main.cipherService,
+                    this.main.collectionService,
+                );
+                const response = await command.run(email, from, to, options);
+
+                this.processResponse(response);
+            });
     }
 }


### PR DESCRIPTION
This proof of concept provides a report over the passwords a given user
has accessed during a specified period of time which address organization users.
The difference between the standard `Event Log` provided through the API or
the user interface (web) is that the `Event Log` provides a kind of audit log
where each interaction is logged and shown as it happens. This results in many cases
to multiple log entries showing the same information (user has view item XY) which
is already really helpful.

There is another scenario, where it would be of interest to a consolidated report of
total items a user has viewed which should be covered with the proof of concept
provided within this merge request.

The report shows each password item just once even the user has viewed it many times.

## Description of returned information

| Field | Description |
|-------|-------------|
| name  | Name of the password item. |
| date  | The date/timestamp when the last event occurred. |
| type  | One of: 1100, 1108, 1109, 1111, 1112 https://bitwarden.com/help/article/event-logs/#item-events |
| type_name | https://bitwarden.com/help/article/event-logs/#item-events |
| collections | Full readable path to the password item (comma separated in case it has multiple references).|
| uri | URL stored as part of the item. |
| last_modified_username | Name of the user, who modified the item last.|
| last_modified_email | Email of the user, who modified the item last. |
| last_modified_date | The date/timestamp when the last password change occurred. |
| last_modified_type_name | https://bitwarden.com/help/article/event-logs/#item-events |
| last_modified_type | https://bitwarden.com/help/article/event-logs/#item-events |

## Help

```
Usage: bw par [options] <email> <from> <to>

Export password access report to a CSV or JSON file.

Options:
  --output <output>                  Output directory or filename.
  --format <format>                  Export file format.
  --organizationid <organizationid>  Organization id for an organization.
  -h, --help                         display help for command

  Notes:

    Valid formats are `csv`, `json`. Default format is `csv`.

    If --raw option is specified and no output filename or directory is given, the
    result is written to stdout.

  Examples:

    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd
    bw par --organizationid example-org-id firstname.lastname@example.com 2021-01-01 2021-07
    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --raw
    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --raw --format csv
    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --format json
    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --output report.csv
    bw par --organizationid example-org-id email yyyy-mm-dd yyyy-mm-dd --output report.json --format json
```

## Example JSON output

```
bw par --organizationid <orgainizationid> <email> 2021-01-01 2021-07 --format json --output report.json

[
  {
    "name": "my-github-user",
    "date": "2021-05-26T16:08:34.34Z",
    "type": "1109",
    "type_name": "Cipher_ClientToggledHiddenFieldVisible",
    "collections": "Github",
    "uri": "https://www.github.com/",
    "last_modified_username": "Firstname Lastname",
    "last_modified_email": "firstname.lastname@example.com",
    "last_modified_date": "2021-05-06T12:15:15.1764103Z",
    "last_modified_type_name": "Cipher_Created",
    "last_modified_type": "1100"
  }
]
```