### PR TITLE
Allow import to organization

### DIFF
--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -25,9 +25,9 @@ export class ImportCommand {
         }
 
         if (options.formats || false) {
-            return this.list();
+            return await this.list();
         } else {
-            return this.import(format, filepath, organizationId);
+            return await this.import(format, filepath, organizationId);
         }
     }
 
@@ -39,7 +39,7 @@ export class ImportCommand {
             return Response.badRequest('`filepath` was not provided.');
         }
 
-        const importer = await this.importService.getImporter(format, null);
+        const importer = await this.importService.getImporter(format, organizationId);
         if (importer === null) {
             return Response.badRequest('Proper importer type required.');
         }

--- a/src/vault.program.ts
+++ b/src/vault.program.ts
@@ -320,16 +320,18 @@ export class VaultProgram extends Program {
             .command('import [format] [input]')
             .description('Import vault data from a file.')
             .option('--formats', 'List formats')
+            .option('--organizationid <organizationid>', 'ID of the organization to import to.')
             .on('--help', () => {
                 writeLn('\n Examples:');
                 writeLn('');
                 writeLn('    bw import --formats');
                 writeLn('    bw import bitwardencsv ./from/source.csv');
                 writeLn('    bw import keepass2xml keepass_backup.xml');
+                writeLn('    bw import --organizationid cf14adc3-aca5-4573-890a-f6fa231436d9 keepass2xml keepass_backup.xml');
             })
             .action(async (format, filepath, options) => {
                 await this.exitIfLocked();
-                const command = new ImportCommand(this.main.importService);
+                const command = new ImportCommand(this.main.importService, this.main.userService);
                 const response = await command.run(format, filepath, options);
                 this.processResponse(response);
             });


### PR DESCRIPTION
# Overview

Closes #317. Add the feature to import into an organization for which the signed-in user has import/export privileges.

# Files Changed
* **import.command.ts**: Check organization privileges and pass organizationId to the import service for import.
* **vault.program.ts**: Add `--organizationid` option.

# Testing

* Regression testing should be done on CLI importing.
* Import into an organization from a slew of formats.
  * Validation that items are imported correctly into the correct organization/personal vault
  * Validation that items are imported into correct folder/colletion

@bitwarden/dept-qa What do you think the testing burden is on this? Can we sneak this into this upcoming release?