### PR TITLE
Redefine cipher "share" to "move"

### DIFF
--- a/src/bw.ts
+++ b/src/bw.ts
@@ -25,7 +25,6 @@ import { ExportService } from 'jslib-common/services/export.service';
 import { FileUploadService } from 'jslib-common/services/fileUpload.service';
 import { FolderService } from 'jslib-common/services/folder.service';
 import { ImportService } from 'jslib-common/services/import.service';
-import { NodeCryptoFunctionService } from 'jslib-common/services/nodeCryptoFunction.service';
 import { NoopMessagingService } from 'jslib-common/services/noopMessaging.service';
 import { PasswordGenerationService } from 'jslib-common/services/passwordGeneration.service';
 import { PolicyService } from 'jslib-common/services/policy.service';
@@ -39,6 +38,7 @@ import { UserService } from 'jslib-common/services/user.service';
 import { VaultTimeoutService } from 'jslib-common/services/vaultTimeout.service';
 import { LowdbStorageService } from 'jslib-node/services/lowdbStorage.service';
 import { NodeApiService } from 'jslib-node/services/nodeApi.service';
+import { NodeCryptoFunctionService } from 'jslib-node/services/nodeCryptoFunction.service';
 
 import { Program } from './program';
 import { SendProgram } from './send.program';

--- a/src/vault.program.ts
+++ b/src/vault.program.ts
@@ -57,14 +57,15 @@ export class VaultProgram extends Program {
             'items',
             'folders',
             'collections',
-            'organizations',
+            'org-collections',
             'org-members',
+            'organizations',
         ];
 
         return new program.Command('list')
             .arguments('<object>')
             .description('List an array of objects from the vault.', {
-                object: 'Object type (choices: "' + listObjects.join('", "') + '")',
+                object: 'Valid objects are: ' + listObjects.join(', '),
             })
             .option('--search <search>', 'Perform a search on the listed objects.')
             .option('--url <url>', 'Filter items of type login with a url-match search.')
@@ -135,7 +136,10 @@ export class VaultProgram extends Program {
             .option('--output <output>', 'Output directory or filename for attachment.')
             .option('--organizationid <organizationid>', 'Organization id for an organization object.')
             .on('--help', () => {
-                writeLn('\n  Examples:');
+                writeLn('\n  If raw output is specified and no output filename or directory is given for');
+                writeLn('  an attachment query, the attachment content is written to stdout.');
+                writeLn('');
+                writeLn('  Examples:');
                 writeLn('');
                 writeLn('    bw get item 99ee88d2-6046-4ea7-92c2-acac464b1412');
                 writeLn('    bw get password https://google.com');
@@ -323,7 +327,7 @@ export class VaultProgram extends Program {
                     'bw ' + commandName + ' 4af958ce-96a7-45d9-beed-1e70fabaa27a 6d82949b-b44d-468a-adae-3f3bacb0ea32');
                 if (deprecated) {
                     writeLn('');
-                    writeLn('---DEPRECATED See "bw move" for the current implementation----');
+                    writeLn('--DEPRECATED See "bw move" for the current implementation--');
                 }
                 writeLn('', true);
             })


### PR DESCRIPTION
# Overview

The term "Share" is confusing to users because it implies maintaining ownership and control of a cipher while allowing others to access it as well. It also implies the ability to revoke access or to stop sharing -- neither of these things is true.

When a cipher is "shared" it is irrevocably taken over by an organization. This occurs for good cryptographic and security reasons. The better solution to this is to revise the communication around "sharing." To that end, this work changes the term "share" to "move".

The "share" command is still present, but is marked as deprecated.

This work also does some tech debt cleanup, bringing style in to line with [send.program.ts](https://github.com/bitwarden/cli/blob/master/src/send.program.ts). It also allows me to reuse the command for both `bw move` and `bw share` while marking `share` as deprecated.

# Files Changed
* **bw.ts**: This is a jslib update artifact -- separate PR exists for this
* **vault.program.ts**: tech debt refactor & deprecate `bw share`

# Screen Shots
#### `bw --help`
<img width="621" alt="image" src="https://user-images.githubusercontent.com/18214891/122558567-d875a500-d003-11eb-8f3c-949dc29551e3.png">

#### `bw share --help`
<img width="621" alt="image" src="https://user-images.githubusercontent.com/18214891/122558638-ee836580-d003-11eb-9c09-2c0686317b16.png">

### New Argument Styling
<img width="621" alt="image" src="https://user-images.githubusercontent.com/18214891/122558942-4752fe00-d004-11eb-8de8-b173d6c8db70.png">

#### Object type unknown error
<img width="621" alt="image" src="https://user-images.githubusercontent.com/18214891/122558820-2094c780-d004-11eb-95e1-9f3abdda7750.png">
