### PR TITLE
Use cryptoservice to compare key to local keyhash

### DIFF
--- a/src/commands/unlock.command.ts
+++ b/src/commands/unlock.command.ts
@@ -13,6 +13,8 @@ import { PasswordVerificationRequest } from 'jslib-common/models/request/passwor
 
 import { Utils } from 'jslib-common/misc/utils';
 
+import { HashPurpose } from 'jslib-common/enums/hashPurpose';
+
 export class UnlockCommand {
     constructor(private cryptoService: CryptoService, private userService: UserService,
         private cryptoFunctionService: CryptoFunctionService, private apiService: ApiService) { }
@@ -36,18 +38,22 @@ export class UnlockCommand {
         const kdf = await this.userService.getKdf();
         const kdfIterations = await this.userService.getKdfIterations();
         const key = await this.cryptoService.makeKey(password, email, kdf, kdfIterations);
+        const storedKeyHash = await this.cryptoService.getKeyHash();
 
         let passwordValid = false;
         if (key != null) {
-            passwordValid = await this.cryptoService.compareAndUpdateKeyHash(password, key);
-            if (!passwordValid) {
-                const keyHash = await this.cryptoService.hashPassword(password, key);
+            if (storedKeyHash != null) {
+                passwordValid = await this.cryptoService.compareAndUpdateKeyHash(password, key);
+            } else {
+                const serverKeyHash = await this.cryptoService.hashPassword(password, key, HashPurpose.ServerAuthorization);
                 const request = new PasswordVerificationRequest();
-                request.masterPasswordHash = keyHash;
+                request.masterPasswordHash = serverKeyHash;
                 try {
                     await this.apiService.postAccountVerifyPassword(request);
                     passwordValid = true;
-                    await this.cryptoService.setKeyHash(keyHash);
+                    const localKeyHash = await this.cryptoService.hashPassword(password, key,
+                        HashPurpose.LocalAuthorization);
+                    await this.cryptoService.setKeyHash(localKeyHash);
                 } catch { }
             }
         }

--- a/src/commands/unlock.command.ts
+++ b/src/commands/unlock.command.ts
@@ -36,14 +36,12 @@ export class UnlockCommand {
         const kdf = await this.userService.getKdf();
         const kdfIterations = await this.userService.getKdfIterations();
         const key = await this.cryptoService.makeKey(password, email, kdf, kdfIterations);
-        const keyHash = await this.cryptoService.hashPassword(password, key);
 
         let passwordValid = false;
-        if (keyHash != null) {
-            const storedKeyHash = await this.cryptoService.getKeyHash();
-            if (storedKeyHash != null) {
-                passwordValid = storedKeyHash === keyHash;
-            } else {
+        if (key != null) {
+            passwordValid = await this.cryptoService.compareAndUpdateKeyHash(password, key);
+            if (!passwordValid) {
+                const keyHash = await this.cryptoService.hashPassword(password, key);
                 const request = new PasswordVerificationRequest();
                 request.masterPasswordHash = keyHash;
                 try {


### PR DESCRIPTION
# Overview

bitwarden/jslib#404 introduced a separate local key hash from remote key hash used for authentication. The unlock command was not honoring this change and so always failed to unlock.

This PR uses `cryptoService's` `compareAndUpdateKeyHash` to validate and upgrade locally stored key hashes.

Authentication key hash is build only in the event that remove verification is necessary

> Note: This will be cherry-picked to `rc`. Please evaluate accordingly