### PR TITLE
Use `getKey` to actually retrieve key.

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -418,6 +418,8 @@ export class Program extends BaseProgram {
             } else {
                 this.processResponse(Response.error('Vault is locked.'), true);
             }
+        } else if (!this.main.cryptoService.hasKeyInMemory()) {
+            await this.main.cryptoService.getKey();
         }
     }
 


### PR DESCRIPTION
# Overview

bitwarden/jslib#402 changed the behavior of `hasKey` to just validate that it's available. Need to `getKey` to retrieve it from storage.

Fixes https://app.asana.com/0/0/1200493308745386/f

> Note: This will be cherry-picked to `rc`. Please evaluate accordingly