### PR TITLE
Fix cli lock and logout

### DIFF
--- a/src/bw.ts
+++ b/src/bw.ts
@@ -137,7 +137,8 @@ export class Main {
             this.storageService, this.i18nService, this.cryptoFunctionService);
         this.vaultTimeoutService = new VaultTimeoutService(this.cipherService, this.folderService,
             this.collectionService, this.cryptoService, this.platformUtilsService, this.storageService,
-            this.messagingService, this.searchService, this.userService, this.tokenService, null, null);
+            this.messagingService, this.searchService, this.userService, this.tokenService,
+            async () => await this.cryptoService.clearStoredKey('auto'), null);
         this.syncService = new SyncService(this.userService, this.apiService, this.settingsService,
             this.folderService, this.cipherService, this.cryptoService, this.collectionService,
             this.storageService, this.messagingService, this.policyService, this.sendService,

--- a/src/services/nodeEnvSecureStorage.service.ts
+++ b/src/services/nodeEnvSecureStorage.service.ts
@@ -19,7 +19,7 @@ export class NodeEnvSecureStorageService implements StorageService {
     }
 
     async has(key: string): Promise<boolean> {
-        return await this.get(key) != null;
+        return (await this.get(key)) != null;
     }
 
     async save(key: string, obj: any): Promise<any> {


### PR DESCRIPTION
# Overview

Corrects two issues with CLI
1. The key needs to be removed from storage in order for the CLI to lock -- otherwise it is always immediately unlocked if `BW_SESSION` is set and correct.
2. Ensures `has` implementation for `nodeEnvSecureStorageService` awaits `get` prior to determining if the value is present and decryptable

> Note: this will be cherry-picked into `rc`. Please evaluate accordingly