### PR TITLE
JSLIB submodule dependence needs to be pulled prior to install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,11 @@ jobs:
           ResourceHacker -open version-info.rc -save version-info.res -action compile
           ResourceHacker -open %WIN_PKG% -save %WIN_PKG% -action addoverwrite -resource version-info.res
 
-      - name: Install
-        run: npm install
-
       - name: Setup sub-module
         run: npm run sub:init
+
+      - name: Install
+        run: npm install
 
       - name: Build & Package
         run: npm run dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,10 +144,8 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           
-      - name: npm setup
-        run: | 
-          npm install
-          npm run sub:init
+      - name: Setup sub-module
+        run: npm run sub:init
 
       - name: npm install
         run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,11 +118,11 @@ jobs:
           ResourceHacker -open version-info.rc -save version-info.res -action compile
           ResourceHacker -open %WIN_PKG% -save %WIN_PKG% -action addoverwrite -resource version-info.res
 
-      - name: Install
-        run: npm install
-
       - name: Setup sub-module
         run: npm run sub:init
+      
+      - name: Install
+        run: npm install
 
       - name: Build & Package
         run: npm run dist


### PR DESCRIPTION
# Overview

CLI's release pipeline is broken due to jslib dependence change. We need to pull jslib in prior to calling install to resolve dependencies properly.