### PR TITLE
Set HashPurpose.LocalAuthorization on export password check

### DIFF
--- a/src/commands/export.command.ts
+++ b/src/commands/export.command.ts
@@ -6,6 +6,8 @@ import { ExportService } from 'jslib-common/abstractions/export.service';
 
 import { Response } from 'jslib-node/cli/models/response';
 
+import { HashPurpose } from 'jslib-common/enums/hashPurpose';
+
 import { CliUtils } from '../utils';
 
 import { Utils } from 'jslib-common/misc/utils';
@@ -27,7 +29,7 @@ export class ExportCommand {
             return Response.badRequest('Master password is required.');
         }
 
-        const keyHash = await this.cryptoService.hashPassword(password, null);
+        const keyHash = await this.cryptoService.hashPassword(password, null, HashPurpose.LocalAuthorization);
         const storedKeyHash = await this.cryptoService.getKeyHash();
         if (storedKeyHash != null && keyHash != null && storedKeyHash === keyHash) {
             let format = options.format;

--- a/src/commands/export.command.ts
+++ b/src/commands/export.command.ts
@@ -6,8 +6,6 @@ import { ExportService } from 'jslib-common/abstractions/export.service';
 
 import { Response } from 'jslib-node/cli/models/response';
 
-import { HashPurpose } from 'jslib-common/enums/hashPurpose';
-
 import { CliUtils } from '../utils';
 
 import { Utils } from 'jslib-common/misc/utils';
@@ -29,9 +27,7 @@ export class ExportCommand {
             return Response.badRequest('Master password is required.');
         }
 
-        const keyHash = await this.cryptoService.hashPassword(password, null, HashPurpose.LocalAuthorization);
-        const storedKeyHash = await this.cryptoService.getKeyHash();
-        if (storedKeyHash != null && keyHash != null && storedKeyHash === keyHash) {
+        if (await this.cryptoService.compareAndUpdateKeyHash(password, null)) {
             let format = options.format;
             if (format !== 'encrypted_json' && format !== 'json') {
                 format = 'csv';


### PR DESCRIPTION
## Objective
In https://github.com/bitwarden/jslib/pull/404 we changed to use different iterations for local and remote hashing. However the password check in export still used the old number of iterations which prevented it from working.

Note: This will be cherry picked to `rc` once merged.