### PR TITLE
Fix pipelines fetch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,23 +48,18 @@ jobs:
           echo "WIN_PKG=$env:WIN_PKG" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "version: $env:pkgVersion"
         env:
-          #WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.0\fetched-v14.16.1-win-x64
           WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.1\fetched-v14.17.0-win-x64
 
       - name: get pkg-fetch
         shell: pwsh
         run: |
           cd $HOME
-          #$fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v3.0/node-v14.16.1-win-x64"
           $fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v3.1/node-v14.17.0-win-x64"
 
           New-Item -ItemType directory -Path .\.pkg-cache
-          #New-Item -ItemType directory -Path .\.pkg-cache\v3.0
-          #Invoke-RestMethod -Uri $fetchedUrl -OutFile ".\.pkg-cache\v3.0\fetched-v14.16.1-win-x64"
           New-Item -ItemType directory -Path .\.pkg-cache\v3.1
           Invoke-RestMethod -Uri $fetchedUrl -OutFile ".\.pkg-cache\v3.1\fetched-v14.17.0-win-x64"
         env:
-          #WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.0\fetched-v14.16.1-win-x64
           WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.1\fetched-v14.17.0-win-x64
 
       - name: Setup Version Info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,19 +48,23 @@ jobs:
           echo "WIN_PKG=$env:WIN_PKG" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "version: $env:pkgVersion"
         env:
-          WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.0\fetched-v14.16.1-win-x64
+          #WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.0\fetched-v14.16.1-win-x64
+          WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.1\fetched-v14.17.0-win-x64
 
       - name: get pkg-fetch
         shell: pwsh
         run: |
           cd $HOME
-          $fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v3.0/node-v14.16.1-win-x64"
+          #$fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v3.0/node-v14.16.1-win-x64"
+          $fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v3.1/node-v14.17.0-win-x64"
 
           New-Item -ItemType directory -Path .\.pkg-cache
           New-Item -ItemType directory -Path .\.pkg-cache\v3.0
-          Invoke-RestMethod -Uri $fetchedUrl -OutFile ".\.pkg-cache\v3.0\fetched-v14.16.1-win-x64"
+          #Invoke-RestMethod -Uri $fetchedUrl -OutFile ".\.pkg-cache\v3.0\fetched-v14.16.1-win-x64"
+          Invoke-RestMethod -Uri $fetchedUrl -OutFile ".\.pkg-cache\v3.1\fetched-v14.17.0-win-x64"
         env:
-          WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.0\fetched-v14.16.1-win-x64
+          #WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.0\fetched-v14.16.1-win-x64
+          WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.1\fetched-v14.17.0-win-x64
 
       - name: Setup Version Info
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,9 @@ jobs:
           $fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v3.1/node-v14.17.0-win-x64"
 
           New-Item -ItemType directory -Path .\.pkg-cache
-          New-Item -ItemType directory -Path .\.pkg-cache\v3.0
+          #New-Item -ItemType directory -Path .\.pkg-cache\v3.0
           #Invoke-RestMethod -Uri $fetchedUrl -OutFile ".\.pkg-cache\v3.0\fetched-v14.16.1-win-x64"
+          New-Item -ItemType directory -Path .\.pkg-cache\v3.1
           Invoke-RestMethod -Uri $fetchedUrl -OutFile ".\.pkg-cache\v3.1\fetched-v14.17.0-win-x64"
         env:
           #WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.0\fetched-v14.16.1-win-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,19 +92,19 @@ jobs:
           echo "WIN_PKG=$env:WIN_PKG" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "version: $env:pkgVersion"
         env:
-          WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.0\fetched-v14.16.1-win-x64
+          WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.1\fetched-v14.17.0-win-x64
 
       - name: get pkg-fetch
         shell: pwsh
         run: |
           cd $HOME
-          $fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v3.0/node-v14.16.1-win-x64"
+          $fetchedUrl = "https://github.com/vercel/pkg-fetch/releases/download/v3.1/node-v14.17.0-win-x64"
 
           New-Item -ItemType directory -Path .\.pkg-cache
-          New-Item -ItemType directory -Path .\.pkg-cache\v3.0
-          Invoke-RestMethod -Uri $fetchedUrl -OutFile ".\.pkg-cache\v3.0\fetched-v14.16.1-win-x64"
+          New-Item -ItemType directory -Path .\.pkg-cache\v3.1
+          Invoke-RestMethod -Uri $fetchedUrl -OutFile ".\.pkg-cache\v3.1\fetched-v14.17.0-win-x64"
         env:
-          WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.0\fetched-v14.16.1-win-x64
+          WIN_PKG: C:\Users\runneradmin\.pkg-cache\v3.1\fetched-v14.17.0-win-x64
 
       - name: Setup Version Info
         shell: pwsh


### PR DESCRIPTION
## Summary
The dependency bumps pinned the `pkg-fetch` package at `v3.1` and we were manually downloading `v3.0`. These changes fix that problem