### PR TITLE
[chore] version bump 1.17.1-patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@bitwarden/cli",
-            "version": "1.17.0",
+            "version": "1.17.1",
             "license": "GPL-3.0-only",
             "dependencies": {
                 "big-integer": "1.6.48",


### PR DESCRIPTION
https://github.com/bitwarden/cli/pull/345 missed the lower package version in package-lock.json