### PR TITLE
Fix unlock env and passwordfile

### DIFF
--- a/src/commands/unlock.command.ts
+++ b/src/commands/unlock.command.ts
@@ -18,11 +18,9 @@ import { NodeUtils } from 'jslib-common/misc/nodeUtils';
 import { ConsoleLogService } from 'jslib-common/services/consoleLog.service';
 
 export class UnlockCommand {
-    private logService: ConsoleLogService;
-
     constructor(private cryptoService: CryptoService, private userService: UserService,
-        private cryptoFunctionService: CryptoFunctionService, private apiService: ApiService) {
-        this.logService = new ConsoleLogService(false);
+        private cryptoFunctionService: CryptoFunctionService, private apiService: ApiService,
+        private logService: ConsoleLogService) {
     }
 
     async run(password: string, options: program.OptionValues) {

--- a/src/commands/unlock.command.ts
+++ b/src/commands/unlock.command.ts
@@ -28,9 +28,9 @@ export class UnlockCommand {
     async run(password: string, options: program.OptionValues) {
         const canInteract = process.env.BW_NOINTERACTION !== 'true';
         if (password == null || password === '') {
-            if (options.passwordfile) {
+            if (options?.passwordfile) {
                 password = await NodeUtils.readFirstLine(options.passwordfile);
-            } else if (options.passwordenv) {
+            } else if (options?.passwordenv) {
                 if (process.env[options.passwordenv]) {
                     password = process.env[options.passwordenv];
                 } else {

--- a/src/program.ts
+++ b/src/program.ts
@@ -208,7 +208,7 @@ export class Program extends BaseProgram {
                 if (!cmd.check) {
                     await this.exitIfNotAuthed();
                     const command = new UnlockCommand(this.main.cryptoService, this.main.userService,
-                        this.main.cryptoFunctionService, this.main.apiService);
+                        this.main.cryptoFunctionService, this.main.apiService, this.main.logService);
                     const response = await command.run(password, cmd);
                     this.processResponse(response);
                 }
@@ -412,7 +412,7 @@ export class Program extends BaseProgram {
             const canInteract = process.env.BW_NOINTERACTION !== 'true';
             if (canInteract) {
                 const command = new UnlockCommand(this.main.cryptoService, this.main.userService,
-                    this.main.cryptoFunctionService, this.main.apiService);
+                    this.main.cryptoFunctionService, this.main.apiService, this.main.logService);
                 const response = await command.run(null, null);
                 if (!response.success) {
                     this.processResponse(response, true);


### PR DESCRIPTION
# Overview

Fixes issues introduced in #347.

1. Log service needs to be passed in as a dependency to handle `--response` flag correctly
2. Handle null `options` in unlock command

# Testing
@bitwarden/dept-qa, This fixes https://app.asana.com/0/1169444489336079/1200526563739905/f