### PR TITLE
Set snapcraft base

### DIFF
--- a/stores/snap/snapcraft.yaml
+++ b/stores/snap/snapcraft.yaml
@@ -3,6 +3,7 @@ version: __version__
 summary: Bitwarden CLI
 description: A secure and free password manager for all of your devices.
 confinement: strict
+base: core18
 apps:
   bw:
     command: bw


### PR DESCRIPTION
# Overview

Snapcraft 5 got rid of default `core` base and now requires specification. `core18` is to the recommended base for most apps. The equivalent of no base specified is `core16`, but that is Ubuntu 16.04, which is in ESM. We should try out `core18` and if it doesn't work, revert to `core16` for this release with plans to figure out and fix for 18