### PR TITLE
Removing branch constraints on when to expose build assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
           cd dist
           ls -alth
 
-      - uses: snapcore/actions-build@6dd3202e55fccbcf8482a61f38fe630d655a2728  # v1.0.8
+      - uses: snapcore/action-build@6dd3202e55fccbcf8482a61f38fe630d655a2728  # v1.0.8
         with:
           path: dist
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1
 
+     - name: Install multipass
+       run: sudo snap install multipass
+
       - name: Print environment
         run: |
           whoami

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,6 @@ jobs:
           }
 
       - name: Create checksums
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: |
           checksum -f="./dist/bw-windows-${env:PACKAGE_VERSION}.zip" `
             -t sha256 | Out-File -Encoding ASCII ./dist/bw-windows-sha256-${env:PACKAGE_VERSION}.txt
@@ -125,49 +124,42 @@ jobs:
             -t sha256 | Out-File -Encoding ASCII ./dist/bw-linux-sha256-${env:PACKAGE_VERSION}.txt
 
       - name: Upload windows zip asset
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with:
           name: bw-windows-${{ env.PACKAGE_VERSION }}.zip
           path: ./dist/bw-windows-${{ env.PACKAGE_VERSION }}.zip
 
       - name: Upload windows checksum asset
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with:
           name: bw-windows-sha256-${{ env.PACKAGE_VERSION }}.txt
           path: ./dist/bw-windows-sha256-${{ env.PACKAGE_VERSION }}.txt
 
       - name: Upload macos zip asset
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with:
           name: bw-macos-${{ env.PACKAGE_VERSION }}.zip
           path: ./dist/bw-macos-${{ env.PACKAGE_VERSION }}.zip
 
       - name: Upload macos checksum asset
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with:
           name: bw-macos-sha256-${{ env.PACKAGE_VERSION }}.txt
           path: ./dist/bw-macos-sha256-${{ env.PACKAGE_VERSION }}.txt
 
       - name: Upload linux zip asset
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with:
           name: bw-linux-${{ env.PACKAGE_VERSION }}.zip
           path: ./dist/bw-linux-${{ env.PACKAGE_VERSION }}.zip
 
       - name: Upload linux checksum asset
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with:
           name: bw-linux-sha256-${{ env.PACKAGE_VERSION }}.txt
           path: ./dist/bw-linux-sha256-${{ env.PACKAGE_VERSION }}.txt
 
       - name: Upload Chocolatey asset
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@v2
         with: 
           name: bitwarden-cli.${{ env.PACKAGE_VERSION }}.nupkg
@@ -178,7 +170,6 @@ jobs:
     name: Build Snap
     runs-on: ubuntu-latest
     needs: cli
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,9 +205,10 @@ jobs:
           cp -r stores/snap/* -t dist/snap
           sed -i s/__version__/${{ env.PACKAGE_VERSION }}/g dist/snap/snapcraft.yaml
           
-          cd dist/snap
+          cd dist
           ls -alth
           snapcraft
+          ls -alth
 
           sha256sum bw_${{ env.PACKAGE_VERSION }}_amd64.snap | awk '{split($0, a); print a[1]}' > bw-snap-sha256-${{ env.PACKAGE_VERSION }}.txt
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Print environment
         run: |
           whoami
-          snapcraft --version
+          #snapcraft --version
           echo "GitHub ref: $GITHUB_REF"
           echo "GitHub event: $GITHUB_EVENT"
           echo "BW Package Version: $PACKAGE_VERSION"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,24 +200,24 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: bw-linux-${{ env.PACKAGE_VERSION }}.zip
-          path: ./dist/snap/local
+          path: ./dist/snap
 
       - name: Build Snap Package
         run: |
           cp -r stores/snap/* -t dist/snap
           sed -i s/__version__/${{ env.PACKAGE_VERSION }}/g dist/snap/snapcraft.yaml
           
-          cd dist
+          cd dist/snap
           ls -alth
 
       - uses: snapcore/action-build@6dd3202e55fccbcf8482a61f38fe630d655a2728  # v1.0.8
         with:
-          path: dist
+          path: dist/snap
 
       - name: Create checksum
         run: |
           #sg lxd -c 'snapcraft --use-lxd'
-          cd dist
+          cd dist/snap
           ls -alth
           sha256sum bw_${{ env.PACKAGE_VERSION }}_amd64.snap | awk '{split($0, a); print a[1]}' > bw-snap-sha256-${{ env.PACKAGE_VERSION }}.txt
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: bw-linux-${{ env.PACKAGE_VERSION }}.zip
-          path: ./dist/snap
+          path: ./dist/snap/local
 
       - name: Build Snap Package
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,10 +180,10 @@ jobs:
           $env:pkgVersion = (Get-Content -Raw -Path ./package.json | ConvertFrom-Json).version
           echo "PACKAGE_VERSION=$env:pkgVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v1
-        with:
-          use_lxd: true
+      #- name: Install Snapcraft
+      #  uses: samuelmeuli/action-snapcraft@v1
+      #  with:
+      #    use_lxd: true
 
       - name: Print environment
         run: |
@@ -209,9 +209,16 @@ jobs:
           
           cd dist
           ls -alth
-          sg lxd -c 'snapcraft --use-lxd'
-          ls -alth
 
+      - uses: snapcore/actions-build@6dd3202e55fccbcf8482a61f38fe630d655a2728  # v1.0.8
+        with:
+          path: dist
+
+      - name: Create checksum
+        run: |
+          #sg lxd -c 'snapcraft --use-lxd'
+          cd dist
+          ls -alth
           sha256sum bw_${{ env.PACKAGE_VERSION }}_amd64.snap | awk '{split($0, a); print a[1]}' > bw-snap-sha256-${{ env.PACKAGE_VERSION }}.txt
 
       - name: Install Snap 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,8 @@ jobs:
           cd dist/snap
           ls -alth
 
-      - uses: snapcore/action-build@6dd3202e55fccbcf8482a61f38fe630d655a2728  # v1.0.8
+      - name: Build snap
+        uses: snapcore/action-build@6dd3202e55fccbcf8482a61f38fe630d655a2728  # v1.0.8
         with:
           path: dist/snap
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,9 +182,8 @@ jobs:
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1
-
-      - name: Install multipass
-        run: sudo snap install multipass
+        with:
+          use_lxd: true
 
       - name: Print environment
         run: |
@@ -210,7 +209,7 @@ jobs:
           
           cd dist
           ls -alth
-          snapcraft
+          sg lxd -c 'snapcraft --use-lxd'
           ls -alth
 
           sha256sum bw_${{ env.PACKAGE_VERSION }}_amd64.snap | awk '{split($0, a); print a[1]}' > bw-snap-sha256-${{ env.PACKAGE_VERSION }}.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,8 +183,8 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1
 
-     - name: Install multipass
-       run: sudo snap install multipass
+      - name: Install multipass
+        run: sudo snap install multipass
 
       - name: Print environment
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,8 @@ jobs:
           cd dist/snap
           ls -alth
 
-      - uses: snapcore/action-build@6dd3202e55fccbcf8482a61f38fe630d655a2728  # v1.0.8
+      - name: Build snap
+        uses: snapcore/action-build@6dd3202e55fccbcf8482a61f38fe630d655a2728  # v1.0.8
         with:
           path: dist/snap
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
           cp -r stores/snap/* -t dist/snap
           sed -i s/__version__/${{ env.PACKAGE_VERSION }}/g dist/snap/snapcraft.yaml
           
-          cd dist/snap
+          cd dist
           ls -alth
           snapcraft
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,10 +288,18 @@ jobs:
           cp -r stores/snap/* -t dist/snap
           sed -i s/__version__/${{ env.PACKAGE_VERSION }}/g dist/snap/snapcraft.yaml
           
-          cd dist
+          cd dist/snap
           ls -alth
-          snapcraft
 
+      - uses: snapcore/action-build@6dd3202e55fccbcf8482a61f38fe630d655a2728  # v1.0.8
+        with:
+          path: dist/snap
+
+      - name: Create checksum
+        run: |
+          #sg lxd -c 'snapcraft --use-lxd'
+          cd dist/snap
+          ls -alth
           sha256sum bw_${{ env.PACKAGE_VERSION }}_amd64.snap | awk '{split($0, a); print a[1]}' > bw-snap-sha256-${{ env.PACKAGE_VERSION }}.txt
 
       - name: Install Snap 

--- a/stores/snap/snapcraft.yaml
+++ b/stores/snap/snapcraft.yaml
@@ -11,6 +11,7 @@ apps:
 parts:
   bw:
     plugin: dump
-    source: local/bw-linux-$SNAPCRAFT_PROJECT_VERSION.zip
-    prepare: |
+    source: ./bw-linux-$SNAPCRAFT_PROJECT_VERSION.zip
+    override-build: |
       chmod +x bw
+      snapcraftctl build

--- a/stores/snap/snapcraft.yaml
+++ b/stores/snap/snapcraft.yaml
@@ -11,6 +11,6 @@ apps:
 parts:
   bw:
     plugin: dump
-    source: bw-linux-$SNAPCRAFT_PROJECT_VERSION.zip
+    source: local/bw-linux-$SNAPCRAFT_PROJECT_VERSION.zip
     prepare: |
       chmod +x bw


### PR DESCRIPTION
## Summary

There really isn't a good reason to be constraining the build assets to only `master` and `rc`. So this PR is removing those constraints in effort to move in the direction of helping shift QA left.

Updating the snapcraft dependencies and config file

This will resolve the untestability of https://github.com/bitwarden/cli/pull/358