### PR TITLE
[Account Switching] [Refactor] Implement new account centric services

### DIFF
--- a/src/bw.ts
+++ b/src/bw.ts
@@ -4,6 +4,8 @@ import * as jsdom from 'jsdom';
 import * as path from 'path';
 
 import { LogLevelType } from 'jslib-common/enums/logLevelType';
+import { StorageKey } from 'jslib-common/enums/storageKey';
+
 
 import { AuthService } from 'jslib-common/services/auth.service';
 
@@ -12,12 +14,16 @@ import { NodeEnvSecureStorageService } from './services/nodeEnvSecureStorage.ser
 
 import { CliPlatformUtilsService } from 'jslib-node/cli/services/cliPlatformUtils.service';
 import { ConsoleLogService } from 'jslib-node/cli/services/consoleLog.service';
+import { LowdbStorageService } from 'jslib-node/services/lowdbStorage.service';
+import { NodeApiService } from 'jslib-node/services/nodeApi.service';
+import { NodeCryptoFunctionService } from 'jslib-node/services/nodeCryptoFunction.service';
 
+import { AccountsManagementService } from 'jslib-common/services/accountsManagement.service';
+import { ActiveAccountService } from 'jslib-common/services/activeAccount.service';
 import { AppIdService } from 'jslib-common/services/appId.service';
 import { AuditService } from 'jslib-common/services/audit.service';
 import { CipherService } from 'jslib-common/services/cipher.service';
 import { CollectionService } from 'jslib-common/services/collection.service';
-import { ConstantsService } from 'jslib-common/services/constants.service';
 import { ContainerService } from 'jslib-common/services/container.service';
 import { CryptoService } from 'jslib-common/services/crypto.service';
 import { EnvironmentService } from 'jslib-common/services/environment.service';
@@ -26,19 +32,18 @@ import { FileUploadService } from 'jslib-common/services/fileUpload.service';
 import { FolderService } from 'jslib-common/services/folder.service';
 import { ImportService } from 'jslib-common/services/import.service';
 import { NoopMessagingService } from 'jslib-common/services/noopMessaging.service';
+import { OrganizationService } from 'jslib-common/services/organization.service';
 import { PasswordGenerationService } from 'jslib-common/services/passwordGeneration.service';
 import { PolicyService } from 'jslib-common/services/policy.service';
+import { ProviderService } from 'jslib-common/services/provider.service';
 import { SearchService } from 'jslib-common/services/search.service';
 import { SendService } from 'jslib-common/services/send.service';
 import { SettingsService } from 'jslib-common/services/settings.service';
+import { StoreService } from 'jslib-common/services/store.service';
 import { SyncService } from 'jslib-common/services/sync.service';
 import { TokenService } from 'jslib-common/services/token.service';
 import { TotpService } from 'jslib-common/services/totp.service';
-import { UserService } from 'jslib-common/services/user.service';
 import { VaultTimeoutService } from 'jslib-common/services/vaultTimeout.service';
-import { LowdbStorageService } from 'jslib-node/services/lowdbStorage.service';
-import { NodeApiService } from 'jslib-node/services/nodeApi.service';
-import { NodeCryptoFunctionService } from 'jslib-node/services/nodeCryptoFunction.service';
 
 import { Program } from './program';
 import { SendProgram } from './send.program';
@@ -56,13 +61,11 @@ export class Main {
     secureStorageService: NodeEnvSecureStorageService;
     i18nService: I18nService;
     platformUtilsService: CliPlatformUtilsService;
-    constantsService: ConstantsService;
     cryptoService: CryptoService;
     tokenService: TokenService;
     appIdService: AppIdService;
     apiService: NodeApiService;
     environmentService: EnvironmentService;
-    userService: UserService;
     settingsService: SettingsService;
     cipherService: CipherService;
     folderService: FolderService;
@@ -85,6 +88,11 @@ export class Main {
     logService: ConsoleLogService;
     sendService: SendService;
     fileUploadService: FileUploadService;
+    activeAccount: ActiveAccountService;
+    accountsManagementService: AccountsManagementService;
+    organizationService: OrganizationService;
+    providerService: ProviderService;
+    storeService: StoreService;
 
     constructor() {
         let p = null;
@@ -111,49 +119,54 @@ export class Main {
         this.storageService = new LowdbStorageService(this.logService, null, p, true);
         this.secureStorageService = new NodeEnvSecureStorageService(this.storageService, this.logService,
             () => this.cryptoService);
-        this.cryptoService = new CryptoService(this.storageService, this.secureStorageService,
-            this.cryptoFunctionService, this.platformUtilsService, this.logService);
+        this.storeService = new StoreService(this.storageService, this.secureStorageService);
+        this.accountsManagementService = new AccountsManagementService(this.storageService, this.secureStorageService);
+        this.activeAccount = new ActiveAccountService(this.accountsManagementService, this.storeService);
+        this.organizationService = new OrganizationService(this.activeAccount);
+        this.providerService = new ProviderService(this.activeAccount);
+        this.cryptoService = new CryptoService(this.cryptoFunctionService, this.platformUtilsService,
+            this.logService, this.activeAccount);
         this.appIdService = new AppIdService(this.storageService);
-        this.tokenService = new TokenService(this.storageService);
+        this.tokenService = new TokenService(this.activeAccount);
         this.messagingService = new NoopMessagingService();
-        this.environmentService = new EnvironmentService(this.storageService);
+        this.environmentService = new EnvironmentService(this.activeAccount);
         this.apiService = new NodeApiService(this.tokenService, this.platformUtilsService, this.environmentService,
             async (expired: boolean) => await this.logout(),
             'Bitwarden_CLI/' + this.platformUtilsService.getApplicationVersion() +
             ' (' + this.platformUtilsService.getDeviceString().toUpperCase() + ')', (clientId, clientSecret) =>
             this.authService.logInApiKey(clientId, clientSecret));
-        this.userService = new UserService(this.tokenService, this.storageService);
         this.containerService = new ContainerService(this.cryptoService);
-        this.settingsService = new SettingsService(this.userService, this.storageService);
+        this.settingsService = new SettingsService(this.activeAccount);
         this.fileUploadService = new FileUploadService(this.logService, this.apiService);
-        this.cipherService = new CipherService(this.cryptoService, this.userService, this.settingsService,
-            this.apiService, this.fileUploadService, this.storageService, this.i18nService, null);
-        this.folderService = new FolderService(this.cryptoService, this.userService, this.apiService,
-            this.storageService, this.i18nService, this.cipherService);
-        this.collectionService = new CollectionService(this.cryptoService, this.userService, this.storageService,
-            this.i18nService);
+        this.cipherService = new CipherService(this.cryptoService, this.settingsService,
+            this.apiService, this.fileUploadService, this.i18nService, null,
+            this.activeAccount);
+        this.folderService = new FolderService(this.cryptoService, this.apiService,
+            this.i18nService, this.cipherService, this.activeAccount);
+        this.collectionService = new CollectionService(this.cryptoService, this.i18nService,
+            this.activeAccount);
         this.searchService = new SearchService(this.cipherService, this.logService, this.i18nService);
-        this.policyService = new PolicyService(this.userService, this.storageService);
-        this.sendService = new SendService(this.cryptoService, this.userService, this.apiService, this.fileUploadService,
-            this.storageService, this.i18nService, this.cryptoFunctionService);
+        this.policyService = new PolicyService(this.activeAccount, this.organizationService);
+        this.sendService = new SendService(this.cryptoService, this.apiService,
+            this.fileUploadService, this.i18nService, this.cryptoFunctionService, this.activeAccount);
         this.vaultTimeoutService = new VaultTimeoutService(this.cipherService, this.folderService,
-            this.collectionService, this.cryptoService, this.platformUtilsService, this.storageService,
-            this.messagingService, this.searchService, this.userService, this.tokenService, this.policyService,
+            this.collectionService, this.cryptoService, this.platformUtilsService, this.messagingService,
+            this.searchService, this.tokenService, this.policyService, this.activeAccount,
             async () => await this.cryptoService.clearStoredKey('auto'), null);
-        this.syncService = new SyncService(this.userService, this.apiService, this.settingsService,
+        this.syncService = new SyncService(this.apiService, this.settingsService,
             this.folderService, this.cipherService, this.cryptoService, this.collectionService,
-            this.storageService, this.messagingService, this.policyService, this.sendService,
-            async (expired: boolean) => await this.logout());
-        this.passwordGenerationService = new PasswordGenerationService(this.cryptoService, this.storageService,
-            this.policyService);
-        this.totpService = new TotpService(this.storageService, this.cryptoFunctionService);
+            this.messagingService, this.policyService, this.sendService, async () => await this.logout(),
+            this.activeAccount, this.organizationService, this.providerService);
+        this.passwordGenerationService = new PasswordGenerationService(this.cryptoService, this.policyService,
+            this.activeAccount);
+        this.totpService = new TotpService(this.cryptoFunctionService, this.activeAccount);
         this.importService = new ImportService(this.cipherService, this.folderService, this.apiService,
             this.i18nService, this.collectionService, this.platformUtilsService, this.cryptoService);
         this.exportService = new ExportService(this.folderService, this.cipherService, this.apiService,
             this.cryptoService);
-        this.authService = new AuthService(this.cryptoService, this.apiService, this.userService, this.tokenService,
+        this.authService = new AuthService(this.cryptoService, this.apiService, this.tokenService,
             this.appIdService, this.i18nService, this.platformUtilsService, this.messagingService,
-            this.vaultTimeoutService, this.logService, true);
+            this.vaultTimeoutService, this.logService, this.activeAccount, this.accountsManagementService, true);
         this.auditService = new AuditService(this.cryptoFunctionService, this.apiService);
         this.program = new Program(this);
         this.vaultProgram = new VaultProgram(this);
@@ -177,17 +190,15 @@ export class Main {
     }
 
     async logout() {
-        const userId = await this.userService.getUserId();
         await Promise.all([
             this.syncService.setLastSync(new Date(0)),
             this.tokenService.clearToken(),
             this.cryptoService.clearKeys(),
-            this.userService.clear(),
-            this.settingsService.clear(userId),
-            this.cipherService.clear(userId),
-            this.folderService.clear(userId),
-            this.collectionService.clear(userId),
-            this.policyService.clear(userId),
+            this.settingsService.clear(),
+            this.cipherService.clear(),
+            this.folderService.clear(),
+            this.collectionService.clear(),
+            this.policyService.clear(),
             this.passwordGenerationService.clear(),
         ]);
         process.env.BW_SESSION = null;
@@ -203,14 +214,14 @@ export class Main {
         //     api: 'http://localhost:4000',
         //     identity: 'http://localhost:33656',
         // });
-        const locale = await this.storageService.get<string>(ConstantsService.localeKey);
+        const locale = await this.storageService.get<string>(StorageKey.Locale);
         await this.i18nService.init(locale);
         this.authService.init();
 
-        const installedVersion = await this.storageService.get<string>(ConstantsService.installedVersionKey);
+        const installedVersion = await this.storageService.get<string>(StorageKey.InstalledVersion);
         const currentVersion = await this.platformUtilsService.getApplicationVersion();
         if (installedVersion == null || installedVersion !== currentVersion) {
-            await this.storageService.save(ConstantsService.installedVersionKey, currentVersion);
+            await this.storageService.save(StorageKey.InstalledVersion, currentVersion);
         }
     }
 }

--- a/src/commands/create.command.ts
+++ b/src/commands/create.command.ts
@@ -2,11 +2,11 @@ import * as program from 'commander';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { ActiveAccountService } from 'jslib-common/abstractions/activeAccount.service';
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { CipherService } from 'jslib-common/abstractions/cipher.service';
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
 import { FolderService } from 'jslib-common/abstractions/folder.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { Cipher } from 'jslib-common/models/export/cipher';
 import { Collection } from 'jslib-common/models/export/collection';
@@ -29,7 +29,7 @@ import { Utils } from 'jslib-common/misc/utils';
 
 export class CreateCommand {
     constructor(private cipherService: CipherService, private folderService: FolderService,
-        private userService: UserService, private cryptoService: CryptoService,
+        private activeAccount: ActiveAccountService, private cryptoService: CryptoService,
         private apiService: ApiService) { }
 
     async run(object: string, requestJson: string, cmd: program.Command): Promise<Response> {
@@ -96,7 +96,7 @@ export class CreateCommand {
             return Response.notFound();
         }
 
-        if (cipher.organizationId == null && !(await this.userService.canAccessPremium())) {
+        if (cipher.organizationId == null && !this.activeAccount.canAccessPremium) {
             return Response.error('Premium status is required to use this feature.');
         }
 

--- a/src/commands/delete.command.ts
+++ b/src/commands/delete.command.ts
@@ -1,9 +1,9 @@
 import * as program from 'commander';
 
+import { ActiveAccountService } from 'jslib-common/abstractions/activeAccount.service';
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { CipherService } from 'jslib-common/abstractions/cipher.service';
 import { FolderService } from 'jslib-common/abstractions/folder.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { Response } from 'jslib-node/cli/models/response';
 
@@ -11,7 +11,7 @@ import { Utils } from 'jslib-common/misc/utils';
 
 export class DeleteCommand {
     constructor(private cipherService: CipherService, private folderService: FolderService,
-        private userService: UserService, private apiService: ApiService) { }
+        private activeAccount: ActiveAccountService, private apiService: ApiService) { }
 
     async run(object: string, id: string, cmd: program.Command): Promise<Response> {
         if (id != null) {
@@ -70,7 +70,7 @@ export class DeleteCommand {
             return Response.error('Attachment `' + id + '` was not found.');
         }
 
-        if (cipher.organizationId == null && !(await this.userService.canAccessPremium())) {
+        if (cipher.organizationId == null && !this.activeAccount.canAccessPremium) {
             return Response.error('Premium status is required to use this feature.');
         }
 

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -1,6 +1,7 @@
 import * as program from 'commander';
+
 import { ImportService } from 'jslib-common/abstractions/import.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
+import { OrganizationService } from 'jslib-common/abstractions/organization.service';
 
 import { Response } from 'jslib-node/cli/models/response';
 import { MessageResponse } from 'jslib-node/cli/models/response/messageResponse';
@@ -8,12 +9,12 @@ import { MessageResponse } from 'jslib-node/cli/models/response/messageResponse'
 import { CliUtils } from '../utils';
 
 export class ImportCommand {
-    constructor(private importService: ImportService, private userService: UserService) { }
+    constructor(private importService: ImportService, private organizationService: OrganizationService) { }
 
     async run(format: string, filepath: string, options: program.OptionValues): Promise<Response> {
         const organizationId = options.organizationid;
         if (organizationId != null) {
-            const organization = await this.userService.getOrganization(organizationId);
+            const organization = await this.organizationService.get(organizationId);
 
             if (organization == null) {
                 return Response.badRequest(`You do not belong to an organization with the ID of ${organizationId}. Check the organization ID and sync your vault.`);

--- a/src/commands/list.command.ts
+++ b/src/commands/list.command.ts
@@ -6,8 +6,8 @@ import { ApiService } from 'jslib-common/abstractions/api.service';
 import { CipherService } from 'jslib-common/abstractions/cipher.service';
 import { CollectionService } from 'jslib-common/abstractions/collection.service';
 import { FolderService } from 'jslib-common/abstractions/folder.service';
+import { OrganizationService } from 'jslib-common/abstractions/organization.service';
 import { SearchService } from 'jslib-common/abstractions/search.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
 
 import {
     CollectionDetailsResponse as ApiCollectionDetailsResponse,
@@ -34,7 +34,7 @@ import { Utils } from 'jslib-common/misc/utils';
 
 export class ListCommand {
     constructor(private cipherService: CipherService, private folderService: FolderService,
-        private collectionService: CollectionService, private userService: UserService,
+        private collectionService: CollectionService, private organizationService: OrganizationService,
         private searchService: SearchService, private apiService: ApiService) { }
 
     async run(object: string, cmd: program.Command): Promise<Response> {
@@ -154,7 +154,7 @@ export class ListCommand {
         if (!Utils.isGuid(options.organizationid)) {
             return Response.error('`' + options.organizationid + '` is not a GUID.');
         }
-        const organization = await this.userService.getOrganization(options.organizationid);
+        const organization = await this.organizationService.get(options.organizationid);
         if (organization == null) {
             return Response.error('Organization not found.');
         }
@@ -186,7 +186,7 @@ export class ListCommand {
         if (!Utils.isGuid(options.organizationid)) {
             return Response.error('`' + options.organizationid + '` is not a GUID.');
         }
-        const organization = await this.userService.getOrganization(options.organizationid);
+        const organization = await this.organizationService.get(options.organizationid);
         if (organization == null) {
             return Response.error('Organization not found.');
         }
@@ -210,7 +210,7 @@ export class ListCommand {
     }
 
     private async listOrganizations(options: program.OptionValues) {
-        let organizations = await this.userService.getAllOrganizations();
+        let organizations = await this.organizationService.getAll();
 
         if (options.search != null && options.search.trim() !== '') {
             organizations = CliUtils.searchOrganizations(organizations, options.search);

--- a/src/commands/send/create.command.ts
+++ b/src/commands/send/create.command.ts
@@ -2,9 +2,9 @@ import * as program from 'commander';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { ActiveAccountService } from 'jslib-common/abstractions/activeAccount.service';
 import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
 import { SendService } from 'jslib-common/abstractions/send.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { SendType } from 'jslib-common/enums/sendType';
 
@@ -19,7 +19,7 @@ import { SendTextResponse } from '../../models/response/sendTextResponse';
 import { CliUtils } from '../../utils';
 
 export class SendCreateCommand {
-    constructor(private sendService: SendService, private userService: UserService,
+    constructor(private sendService: SendService, private activeAccount: ActiveAccountService,
         private environmentService: EnvironmentService) { }
 
     async run(requestJson: string, options: program.OptionValues) {
@@ -67,7 +67,7 @@ export class SendCreateCommand {
 
         switch (req.type) {
             case SendType.File:
-                if (!(await this.userService.canAccessPremium())) {
+                if (!this.activeAccount.canAccessPremium) {
                     return Response.error('Premium status is required to use this feature.');
                 }
 

--- a/src/commands/send/edit.command.ts
+++ b/src/commands/send/edit.command.ts
@@ -1,8 +1,7 @@
 import * as program from 'commander';
 
-import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
+import { ActiveAccountService } from 'jslib-common/abstractions/activeAccount.service';
 import { SendService } from 'jslib-common/abstractions/send.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { SendType } from 'jslib-common/enums/sendType';
 import { Response } from 'jslib-node/cli/models/response';
@@ -13,7 +12,7 @@ import { CliUtils } from '../../utils';
 import { SendGetCommand } from './get.command';
 
 export class SendEditCommand {
-    constructor(private sendService: SendService, private userService: UserService,
+    constructor(private sendService: SendService, private activeAccount: ActiveAccountService,
         private getCommand: SendGetCommand) { }
 
     async run(encodedJson: string, options: program.OptionValues): Promise<Response> {
@@ -49,7 +48,7 @@ export class SendEditCommand {
             return Response.badRequest('Cannot change a Send\'s type');
         }
 
-        if (send.type === SendType.File && !(await this.userService.canAccessPremium())) {
+        if (send.type === SendType.File && !this.activeAccount.canAccessPremium) {
             return Response.error('Premium status is required to use this feature.');
         }
 

--- a/src/commands/unlock.command.ts
+++ b/src/commands/unlock.command.ts
@@ -1,24 +1,27 @@
 import * as program from 'commander';
 import * as inquirer from 'inquirer';
 
+import { ActiveAccountService } from 'jslib-common/abstractions/activeAccount.service';
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
 import { CryptoFunctionService } from 'jslib-common/abstractions/cryptoFunction.service';
-import { UserService } from 'jslib-common/abstractions/user.service';
+
+import { ConsoleLogService } from 'jslib-common/services/consoleLog.service';
 
 import { Response } from 'jslib-node/cli/models/response';
 import { MessageResponse } from 'jslib-node/cli/models/response/messageResponse';
 
 import { PasswordVerificationRequest } from 'jslib-common/models/request/passwordVerificationRequest';
 
+import { NodeUtils } from 'jslib-common/misc/nodeUtils';
 import { Utils } from 'jslib-common/misc/utils';
 
 import { HashPurpose } from 'jslib-common/enums/hashPurpose';
-import { NodeUtils } from 'jslib-common/misc/nodeUtils';
-import { ConsoleLogService } from 'jslib-common/services/consoleLog.service';
+import { KdfType } from 'jslib-common/enums/kdfType';
+import { StorageKey } from 'jslib-common/enums/storageKey';
 
 export class UnlockCommand {
-    constructor(private cryptoService: CryptoService, private userService: UserService,
+    constructor(private cryptoService: CryptoService, private activeAccount: ActiveAccountService,
         private cryptoFunctionService: CryptoFunctionService, private apiService: ApiService,
         private logService: ConsoleLogService) {
     }
@@ -52,9 +55,9 @@ export class UnlockCommand {
         }
 
         this.setNewSessionKey();
-        const email = await this.userService.getEmail();
-        const kdf = await this.userService.getKdf();
-        const kdfIterations = await this.userService.getKdfIterations();
+        const email = this.activeAccount.email;
+        const kdf = await this.activeAccount.getInformation<KdfType>(StorageKey.KdfType);
+        const kdfIterations = await this.activeAccount.getInformation<number>(StorageKey.KdfIterations);
         const key = await this.cryptoService.makeKey(password, email, kdf, kdfIterations);
         const storedKeyHash = await this.cryptoService.getKeyHash();
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -29,7 +29,7 @@ const writeLn = CliUtils.writeLn;
 
 export class Program extends BaseProgram {
     constructor(protected main: Main) {
-        super(main.userService, writeLn);
+        super(main.activeAccount, writeLn);
     }
 
     async register() {
@@ -110,8 +110,7 @@ export class Program extends BaseProgram {
             .option('--passwordenv <passwordenv>', 'Environment variable storing your password')
             .option('--passwordfile <passwordfile>', 'Path to a file containing your password as its first line')
             .option('--check', 'Check login status.', async () => {
-                const authed = await this.main.userService.isAuthenticated();
-                if (authed) {
+                if (this.main.activeAccount.isAuthenticated) {
                     const res = new MessageResponse('You are logged in!', null);
                     this.processResponse(Response.success(res), true);
                 }
@@ -138,7 +137,7 @@ export class Program extends BaseProgram {
                     const command = new LoginCommand(this.main.authService, this.main.apiService,
                         this.main.cryptoFunctionService, this.main.syncService, this.main.i18nService,
                         this.main.environmentService, this.main.passwordGenerationService,
-                        this.main.platformUtilsService, this.main.userService, this.main.cryptoService,
+                        this.main.platformUtilsService, this.main.activeAccount, this.main.cryptoService,
                         this.main.policyService, async () => await this.main.logout());
                     const response = await command.run(email, password, options);
                     this.processResponse(response);
@@ -208,7 +207,7 @@ export class Program extends BaseProgram {
             .action(async (password, cmd) => {
                 if (!cmd.check) {
                     await this.exitIfNotAuthed();
-                    const command = new UnlockCommand(this.main.cryptoService, this.main.userService,
+                    const command = new UnlockCommand(this.main.cryptoService, this.main.activeAccount,
                         this.main.cryptoFunctionService, this.main.apiService, this.main.logService);
                     const response = await command.run(password, cmd);
                     this.processResponse(response);
@@ -391,7 +390,7 @@ export class Program extends BaseProgram {
                 const command = new StatusCommand(
                     this.main.environmentService,
                     this.main.syncService,
-                    this.main.userService,
+                    this.main.activeAccount,
                     this.main.vaultTimeoutService);
                 const response = await command.run();
                 this.processResponse(response);
@@ -414,7 +413,7 @@ export class Program extends BaseProgram {
         if (!hasKey) {
             const canInteract = process.env.BW_NOINTERACTION !== 'true';
             if (canInteract) {
-                const command = new UnlockCommand(this.main.cryptoService, this.main.userService,
+                const command = new UnlockCommand(this.main.cryptoService, this.main.activeAccount,
                     this.main.cryptoFunctionService, this.main.apiService, this.main.logService);
                 const response = await command.run(null, null);
                 if (!response.success) {
@@ -427,5 +426,4 @@ export class Program extends BaseProgram {
             await this.main.cryptoService.getKey();
         }
     }
-
 }

--- a/src/send.program.ts
+++ b/src/send.program.ts
@@ -119,8 +119,7 @@ export class SendProgram extends Program {
             .action(async object => {
                 const cmd = new GetCommand(this.main.cipherService, this.main.folderService,
                     this.main.collectionService, this.main.totpService, this.main.auditService, this.main.cryptoService,
-                    this.main.userService, this.main.searchService, this.main.apiService, this.main.sendService,
-                    this.main.environmentService);
+                    this.main.activeAccount, this.main.searchService, this.main.apiService, this.main.organizationService);
                 const response = await cmd.run('template', object, null);
                 this.processResponse(response);
             });
@@ -208,7 +207,7 @@ export class SendProgram extends Program {
                 await this.exitIfLocked();
                 const getCmd = new SendGetCommand(this.main.sendService, this.main.environmentService,
                     this.main.searchService, this.main.cryptoService);
-                const cmd = new SendEditCommand(this.main.sendService, this.main.userService, getCmd);
+                const cmd = new SendEditCommand(this.main.sendService, this.main.activeAccount, getCmd);
                 const response = await cmd.run(encodedJson, options);
                 this.processResponse(response);
             });
@@ -273,7 +272,7 @@ export class SendProgram extends Program {
 
     private async runCreate(encodedJson: string, options: program.OptionValues) {
         await this.exitIfLocked();
-        const cmd = new SendCreateCommand(this.main.sendService, this.main.userService,
+        const cmd = new SendCreateCommand(this.main.sendService, this.main.activeAccount,
             this.main.environmentService);
         return await cmd.run(encodedJson, options);
     }

--- a/src/vault.program.ts
+++ b/src/vault.program.ts
@@ -101,7 +101,7 @@ export class VaultProgram extends Program {
 
                 await this.exitIfLocked();
                 const command = new ListCommand(this.main.cipherService, this.main.folderService,
-                    this.main.collectionService, this.main.userService, this.main.searchService, this.main.apiService);
+                    this.main.collectionService, this.main.organizationService, this.main.searchService, this.main.apiService);
                 const response = await command.run(object, cmd);
 
                 this.processResponse(response);
@@ -161,8 +161,8 @@ export class VaultProgram extends Program {
                 await this.exitIfLocked();
                 const command = new GetCommand(this.main.cipherService, this.main.folderService,
                     this.main.collectionService, this.main.totpService, this.main.auditService,
-                    this.main.cryptoService, this.main.userService, this.main.searchService,
-                    this.main.apiService, this.main.sendService, this.main.environmentService);
+                    this.main.cryptoService, this.main.activeAccount, this.main.searchService,
+                    this.main.apiService, this.main.organizationService);
                 const response = await command.run(object, id, cmd);
                 this.processResponse(response);
             });
@@ -200,7 +200,7 @@ export class VaultProgram extends Program {
 
                 await this.exitIfLocked();
                 const command = new CreateCommand(this.main.cipherService, this.main.folderService,
-                    this.main.userService, this.main.cryptoService, this.main.apiService);
+                    this.main.activeAccount, this.main.cryptoService, this.main.apiService);
                 const response = await command.run(object, encodedJson, cmd);
                 this.processResponse(response);
             });
@@ -276,7 +276,7 @@ export class VaultProgram extends Program {
 
                 await this.exitIfLocked();
                 const command = new DeleteCommand(this.main.cipherService, this.main.folderService,
-                    this.main.userService, this.main.apiService);
+                    this.main.activeAccount, this.main.apiService);
                 const response = await command.run(object, id, cmd);
                 this.processResponse(response);
             });
@@ -388,7 +388,7 @@ export class VaultProgram extends Program {
             })
             .action(async (format, filepath, options) => {
                 await this.exitIfLocked();
-                const command = new ImportCommand(this.main.importService, this.main.userService);
+                const command = new ImportCommand(this.main.importService, this.main.organizationService);
                 const response = await command.run(format, filepath, options);
                 this.processResponse(response);
             });


### PR DESCRIPTION
### Related Work
* **[jslib Dependency]** https://github.com/bitwarden/jslib/pull/491
* [Asana Task](https://app.asana.com/0/1200804338582616/1200940942987458)

Several refactors were done on the data storage layer of jslib to support Account Switching for desktop.
These changes have been implemented here for parity across clients, improved readability, and to make it easier
to add Account Switching to other clients later if desired.

### Object
> Refactor BW clients to use new data storage access patterns that are being used by desktop to achieve Account Switching for that client.

### Code Changes
* The UserService was removed, and so all references have been replaced with the new access points for that data (activeAccount and organizationService most often)
* The StorageService is now considered a "global" scope, where as we have a new "account" scope to consider. Any "account" scope storage items I have moved to saving with
an ActiveAccountService instance instead of a StorageService instance.
* ConstantsServices have been removed and replaced with a StorageKey enum that holds keys that were in ConstantServices and in other feature scoped services.

### Testing Considerations
> There are no functional changes here, but the storage mechanism for the entire app was swapped. We should perform a regression here, specifically surrounding login and settings.