### PR TITLE
Updating release branch constraint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           if [[ "$GITHUB_REF" != "refs/heads/release" ]]; then
             echo "==================================="
-            echo "[!] Can only release from the 'release' branches"
+            echo "[!] Can only release from the 'release' branch"
             echo "==================================="
             exit 1
           fi


### PR DESCRIPTION
## Summary

We are iterating on our release branching strategy to include the `release` branch. This PR updates the constrained branch to `release` and adds some CI pipeline code flexibility by allowing the release of `release` from `master`.