### PR TITLE
fixing the cli release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,10 @@ jobs:
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
 
+      - name: Make dist dir
+        shell: pwsh
+        run: New-Item -ItemType directory -Path ./dist
+
       - name: Download artifacts
         uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
         with:
@@ -133,16 +137,21 @@ jobs:
           workflow_conclusion: success
           branch: release
           artifacts: bitwarden-cli.${{ env._PKG_VERSION }}.nupkg
+          path: ./dist
 
       - name: Push to Chocolatey
         shell: pwsh
-        run: choco push
+        run: |
+          cd dist
+          choco push
 
 
   npm:
     name: Publish NPM
     runs-on: ubuntu-20.04
     needs: setup
+    env:
+      _PKG_VERSION: ${{ needs.setup.outputs.package_version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -155,7 +164,7 @@ jobs:
           workflow: build.yml
           workflow_conclusion: success
           branch: release
-          artifacts: bitwarden-cli-${{ env._PACKAGE_VERSION }}-npm-build.zip
+          artifacts: bitwarden-cli-${{ env._PKG_VERSION }}-npm-build.zip
 
       - name: Setup NPM
         run: |


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix the release workflow so that we can successfully release CLI in the future

## Code changes
- For some reason, `choco` has to release from the `./dist` directory. I'm guessing that it is a configuration setting somewhere.
- Adding the _PKG_VERSION env var to the npm job
