### PR TITLE
Update year in copyright

### DIFF
--- a/stores/chocolatey/bitwarden-cli.nuspec
+++ b/stores/chocolatey/bitwarden-cli.nuspec
@@ -10,7 +10,7 @@
     <authors>Bitwarden Inc.</authors>
     <projectUrl>https://bitwarden.com/</projectUrl>
     <iconUrl>https://cdn.rawgit.com/bitwarden/desktop/51dd1341/resources/icon.png</iconUrl>
-    <copyright>Copyright © 2015-2021 Bitwarden Inc.</copyright>
+    <copyright>Copyright © 2015-2022 Bitwarden Inc.</copyright>
     <projectSourceUrl>https://github.com/bitwarden/cli/</projectSourceUrl>
     <docsUrl>https://help.bitwarden.com/article/cli/</docsUrl>
     <bugTrackerUrl>https://github.com/bitwarden/cli/issues</bugTrackerUrl>


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other

## Objective

As the year 2022 has arrived it's time to update our copyright in various places.

Asana task: https://app.asana.com/0/0/1201609982295255/f

## Code changes
- **stores/chocolatey/bitwarden-cli.nuspec:** Update year in copyright to 2022

## Testing requirements
Nothing really to test here other than to verify we show the current year in the copyright.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)