### PR TITLE
Fix/lowdb no cache

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Apply Prettier https://github.com/bitwarden/cli/pull/426
 910b4a24e649f21acbf4da5b2d422b121d514bd5
+
+# jslib Apply Prettier https://github.com/bitwarden/jslib/pull/581
+193434461dbd9c48fe5dcbad95693470aec422ac

--- a/src/bw.ts
+++ b/src/bw.ts
@@ -120,7 +120,7 @@ export class Main {
       (level) => process.env.BITWARDENCLI_DEBUG !== "true" && level <= LogLevelType.Info
     );
     this.cryptoFunctionService = new NodeCryptoFunctionService();
-    this.storageService = new LowdbStorageService(this.logService, null, p, true);
+    this.storageService = new LowdbStorageService(this.logService, null, p, false);
     this.secureStorageService = new NodeEnvSecureStorageService(
       this.storageService,
       this.logService,

--- a/src/program.ts
+++ b/src/program.ts
@@ -501,7 +501,7 @@ export class Program extends BaseProgram {
       } else {
         this.processResponse(Response.error("Vault is locked."), true);
       }
-    } else if (!this.main.cryptoService.hasKeyInMemory()) {
+    } else if (!await this.main.cryptoService.hasKeyInMemory()) {
       await this.main.cryptoService.getKey();
     }
   }

--- a/src/program.ts
+++ b/src/program.ts
@@ -23,8 +23,9 @@ import { MessageResponse } from "jslib-node/cli/models/response/messageResponse"
 import { TemplateResponse } from "./models/response/templateResponse";
 import { CliUtils } from "./utils";
 
-import { KeySuffixOptions } from 'jslib-common/enums/keySuffixOptions';
 import { BaseProgram } from "jslib-node/cli/baseProgram";
+
+import { KeySuffixOptions } from 'jslib-common/enums/keySuffixOptions';
 
 const writeLn = CliUtils.writeLn;
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -23,8 +23,8 @@ import { MessageResponse } from "jslib-node/cli/models/response/messageResponse"
 import { TemplateResponse } from "./models/response/templateResponse";
 import { CliUtils } from "./utils";
 
-import { BaseProgram } from "jslib-node/cli/baseProgram";
 import { KeySuffixOptions } from 'jslib-common/enums/keySuffixOptions';
+import { BaseProgram } from "jslib-node/cli/baseProgram";
 
 const writeLn = CliUtils.writeLn;
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -25,7 +25,7 @@ import { CliUtils } from "./utils";
 
 import { BaseProgram } from "jslib-node/cli/baseProgram";
 
-import { KeySuffixOptions } from 'jslib-common/enums/keySuffixOptions';
+import { KeySuffixOptions } from "jslib-common/enums/keySuffixOptions";
 
 const writeLn = CliUtils.writeLn;
 
@@ -485,7 +485,7 @@ export class Program extends BaseProgram {
       if (await this.main.keyConnectorService.getUsesKeyConnector()) {
         const response = Response.error(
           "Your vault is locked. You must unlock your vault using your session key.\n" +
-          "If you do not have your session key, you can get a new one by logging out and logging in again."
+            "If you do not have your session key, you can get a new one by logging out and logging in again."
         );
         this.processResponse(response, true);
       } else {

--- a/src/services/nodeEnvSecureStorage.service.ts
+++ b/src/services/nodeEnvSecureStorage.service.ts
@@ -26,7 +26,11 @@ export class NodeEnvSecureStorageService implements StorageService {
   }
 
   async save(key: string, obj: any): Promise<any> {
-    if (typeof obj !== "string") {
+    if (obj == null) {
+      return this.remove(key);
+    }
+
+    if (obj !== null && typeof obj !== "string") {
       throw new Error("Only string storage is allowed.");
     }
     const protectedObj = await this.encrypt(obj);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes a number of issues with the initial account switching implementation in CLI.
1. Remove key from nodeEnvSecureStorage if object value is null
  * This is in line with the way that our `get`/`set` model on `StateService` works
2.  Remove lowdb caching
  * Fixes and issue where partial account states are sometimes stored.
3. Fix `exitIfLocked` logic
  * `hasKey` returns true if the key is accessible by any means, including from storage. We were failing to await loading the key into memory.
  * Because `hasKey` was returning true if a stored session key existed at _all_, regardless of if it was set, we were skipping over the possibility of manually unlocking without regard for session keys. This is now fixed with a cascading `if`/`else if`.

tickets: 
* https://app.asana.com/0/0/1201638560333657/f
* https://app.asana.com/0/0/1201638560333658/f

## Code changes
* **.git-blame-ignore-rebs**: We're only able to supply a single file for git blame ignores, but we want to ignore jslib commits as well in IDEs. Since git commits are hashes, there's virtually no chance of collisions with other commits.
* **bw.ts**: Remove lowdb caching.
* **program.ts**: Fix command unlocking

## Testing requirements

Regression testing due to account switching is required.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
