### PR TITLE
Enable upload of assets via stdin

### DIFF
--- a/src/commands/create.command.ts
+++ b/src/commands/create.command.ts
@@ -89,9 +89,12 @@ export class CreateCommand {
     if (options.file == null || options.file === "") {
       return Response.badRequest("--file <file> required.");
     }
-    const filePath = path.resolve(options.file);
-    if (!fs.existsSync(options.file)) {
-      return Response.badRequest("Cannot find file at " + filePath);
+    let filePath = options.file;
+    if (options.stdin !== true) {
+      filePath = path.resolve(options.file);
+      if (!fs.existsSync(options.file)) {
+        return Response.badRequest("Cannot find file at " + filePath);
+      }
     }
 
     const itemId = options.itemid.toLowerCase();
@@ -113,7 +116,7 @@ export class CreateCommand {
     }
 
     try {
-      const fileBuf = fs.readFileSync(filePath);
+      const fileBuf = fs.readFileSync(options.stdin === true ? 0 : filePath);
       await this.cipherService.saveAttachmentRawWithServer(
         cipher,
         path.basename(filePath),

--- a/src/vault.program.ts
+++ b/src/vault.program.ts
@@ -208,7 +208,11 @@ export class VaultProgram extends Program {
         object: "Valid objects are: " + createObjects.join(", "),
         encodedJson: "Encoded json of the object to create. Can also be piped into stdin.",
       })
-      .option("--file <file>", "Path to file for attachment.")
+      .option(
+        "--file <file>",
+        "Path to file for attachment or the name of the file to store if --stdin was provided."
+      )
+      .option("--stdin", "Tells that the attachment content should be received via stdin.")
       .option("--itemid <itemid>", "Attachment's item id.")
       .option("--organizationid <organizationid>", "Organization id for an organization object.")
       .on("--help", () => {
@@ -218,6 +222,10 @@ export class VaultProgram extends Program {
         writeLn("    echo 'eyJuYW1lIjoiTXkgRm9sZGVyIn0K' | bw create folder");
         writeLn(
           "    bw create attachment --file ./myfile.csv " +
+            "--itemid 16b15b89-65b3-4639-ad2a-95052a6d8f66"
+        );
+        writeLn(
+          "    echo 'hello, world!' | bw create attachment --file myfile.txt --stdin " +
             "--itemid 16b15b89-65b3-4639-ad2a-95052a6d8f66"
         );
         writeLn("", true);


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Enable upload of assets via `stdin`. Just assuming the virtual device `/dev/stdin` to use for that is not enough, as not supportet on Windows.

## Code changes

1. `src/vault.program.ts` registering a new bool flag `--stdin` to enable to receive the file content via `stdin` (plus an example).
2. `src/commands/create.command.ts` 

## Testing requirements
1. Test that already existing creation of assets are still working (so via `--file <xx>`) as it was before.
2. Test that the upload via `--file <name> --stdin` is working as described.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] This change requires a **documentation update** (notify the documentation team) 
     > ℹ️ Not really required but encouraged.
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
