### PR TITLE
Feature/put serve behind feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 build
 dist
+
+config/local.json

--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,30 @@
+function load(envName) {
+  return {
+    ...loadConfig(envName),
+    ...loadConfig("local"),
+  };
+}
+
+function log(configObj) {
+  const repeatNum = 50;
+  console.log(`${"=".repeat(repeatNum)}\nenvConfig`);
+  console.log(JSON.stringify(configObj, null, 2));
+  console.log(`${"=".repeat(repeatNum)}`);
+}
+
+function loadConfig(configName) {
+  try {
+    return require(`./${configName}.json`);
+  } catch (e) {
+    if (e instanceof Error && e.code === "MODULE_NOT_FOUND") {
+      return {};
+    } else {
+      throw e;
+    }
+  }
+}
+
+module.exports = {
+  load,
+  log,
+};

--- a/config/development.json
+++ b/config/development.json
@@ -1,0 +1,5 @@
+{
+  "flags": {
+    "serve": true
+  }
+}

--- a/config/production.json
+++ b/config/production.json
@@ -1,0 +1,5 @@
+{
+  "flags": {
+    "serve": false
+  }
+}

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -1,25 +1,25 @@
-import { FlagName } from '../src/flags';
-import { CliUtils } from '../src/utils';
+import { FlagName } from "../src/flags";
+import { CliUtils } from "../src/utils";
 describe("flagEnabled", () => {
-  it('is true if flag is null', () => {
+  it("is true if flag is null", () => {
     process.env.FLAGS = JSON.stringify({ test: null });
 
     expect(CliUtils.flagEnabled("test" as FlagName)).toBe(true);
   });
 
-  it('is true if flag is undefined', () => {
+  it("is true if flag is undefined", () => {
     process.env.FLAGS = JSON.stringify({});
 
     expect(CliUtils.flagEnabled("test" as FlagName)).toBe(true);
   });
 
-  it('is true if flag is true', () => {
+  it("is true if flag is true", () => {
     process.env.FLAGS = JSON.stringify({ test: true });
 
     expect(CliUtils.flagEnabled("test" as FlagName)).toBe(true);
   });
 
-  it('is false if flag is false', () => {
+  it("is false if flag is false", () => {
     process.env.FLAGS = JSON.stringify({ test: false });
 
     expect(CliUtils.flagEnabled("test" as FlagName)).toBe(false);

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -1,0 +1,27 @@
+import { FlagName } from '../src/flags';
+import { CliUtils } from '../src/utils';
+describe("flagEnabled", () => {
+  it('is true if flag is null', () => {
+    process.env.FLAGS = JSON.stringify({ test: null });
+
+    expect(CliUtils.flagEnabled("test" as FlagName)).toBe(true);
+  });
+
+  it('is true if flag is undefined', () => {
+    process.env.FLAGS = JSON.stringify({});
+
+    expect(CliUtils.flagEnabled("test" as FlagName)).toBe(true);
+  });
+
+  it('is true if flag is true', () => {
+    process.env.FLAGS = JSON.stringify({ test: true });
+
+    expect(CliUtils.flagEnabled("test" as FlagName)).toBe(true);
+  });
+
+  it('is false if flag is false', () => {
+    process.env.FLAGS = JSON.stringify({ test: false });
+
+    expect(CliUtils.flagEnabled("test" as FlagName)).toBe(false);
+  });
+});

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,0 +1,5 @@
+export type Flags = {
+  serve?: boolean;
+};
+
+export type FlagName = keyof Flags;

--- a/src/program.ts
+++ b/src/program.ts
@@ -468,22 +468,24 @@ export class Program extends BaseProgram {
         this.processResponse(response);
       });
 
-    program
-      .command("serve")
-      .description("Start a RESTful API webserver.")
-      .option("--port <port>", "The port to run your API webserver on. Default port is 8087.")
-      .on("--help", () => {
-        writeLn("\n  Examples:");
-        writeLn("");
-        writeLn("    bw serve");
-        writeLn("    bw serve --port 8080");
-        writeLn("", true);
-      })
-      .action(async (cmd) => {
-        await this.exitIfNotAuthed();
-        const command = new ServeCommand(this.main);
-        await command.run(cmd);
-      });
+    if (CliUtils.flagEnabled("serve")) {
+      program
+        .command("serve")
+        .description("Start a RESTful API webserver.")
+        .option("--port <port>", "The port to run your API webserver on. Default port is 8087.")
+        .on("--help", () => {
+          writeLn("\n  Examples:");
+          writeLn("");
+          writeLn("    bw serve");
+          writeLn("    bw serve --port 8080");
+          writeLn("", true);
+        })
+        .action(async (cmd) => {
+          await this.exitIfNotAuthed();
+          const command = new ServeCommand(this.main);
+          await command.run(cmd);
+        });
+    }
   }
 
   protected processResponse(response: Response, exitImmediately = false) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import { CollectionView } from "jslib-common/models/view/collectionView";
 import { FolderView } from "jslib-common/models/view/folderView";
 
 import { NodeUtils } from "jslib-common/misc/nodeUtils";
-import { FlagName, Flags } from './flags';
+import { FlagName, Flags } from "./flags";
 
 export class CliUtils {
   static writeLn(s: string, finalLine: boolean = false, error: boolean = false) {
@@ -183,7 +183,7 @@ export class CliUtils {
   private static get flags(): Flags {
     const envFlags = process.env.FLAGS;
 
-    if (typeof envFlags === 'string') {
+    if (typeof envFlags === "string") {
       return JSON.parse(envFlags) as Flags;
     } else {
       return envFlags as Flags;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ import { CollectionView } from "jslib-common/models/view/collectionView";
 import { FolderView } from "jslib-common/models/view/folderView";
 
 import { NodeUtils } from "jslib-common/misc/nodeUtils";
+import { FlagName, Flags } from './flags';
 
 export class CliUtils {
   static writeLn(s: string, finalLine: boolean = false, error: boolean = false) {
@@ -173,5 +174,19 @@ export class CliUtils {
 
   static convertBooleanOption(optionValue: any) {
     return optionValue || optionValue === "" ? true : false;
+  }
+
+  static flagEnabled(flag: FlagName) {
+    return this.flags[flag] == null || this.flags[flag];
+  }
+
+  private static get flags(): Flags {
+    const envFlags = process.env.FLAGS;
+
+    if (typeof envFlags === 'string') {
+      return JSON.parse(envFlags) as Flags;
+    } else {
+      return envFlags as Flags;
+    }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const nodeExternals = require("webpack-node-externals");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const config = require("./config/config");
 
-
 if (process.env.NODE_ENV == null) {
   process.env.NODE_ENV = "development";
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,16 @@ const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const nodeExternals = require("webpack-node-externals");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
+const config = require("./config/config");
+
 
 if (process.env.NODE_ENV == null) {
   process.env.NODE_ENV = "development";
 }
 const ENV = (process.env.ENV = process.env.NODE_ENV);
+
+const envConfig = config.load(ENV);
+config.log(envConfig);
 
 const moduleRules = [
   {
@@ -39,9 +44,13 @@ const plugins = [
     resourceRegExp: /^encoding$/,
     contextRegExp: /node-fetch/,
   }),
+  new webpack.EnvironmentPlugin({
+    BWCLI_ENV: ENV,
+    FLAGS: envConfig.flags,
+  }),
 ];
 
-const config = {
+const webpackConfig = {
   mode: ENV,
   target: "node",
   devtool: ENV === "development" ? "eval-source-map" : "source-map",
@@ -70,4 +79,4 @@ const config = {
   externals: [nodeExternals()],
 };
 
-module.exports = config;
+module.exports = webpackConfig;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

We've decided to put `bw serve` behind a turned-off feature flag for the time being to buy more testing time. This is also a pretty good chance to put test out our first pass at turning off features with compile-time flags.

## Code changes
I've copied a lot of our configuration framework from bitwarden/web here so we can differentially load config files based off of build environment. There are two defined here, `development` and `production`. Our build pipelines use `npm run dist` to build, which uses `NODE_ENV=production`. To enable a flag, we just need to update the relevant `.json` file's flag to `true`.

* **.gitignore**: Just like web, we have a local override file. This adds that override to gitignore.
* **config.js**: Stolen from web, but we don't have a base or dev configs, since they're not useful.
* **development.json**: development config: serve enabled
* **production.json**: production config: serve disabled
* **utils.spec.ts**: test `flagEnabled` helper method behaves with the expected default-enabled behavior
* **flags.ts**: Typescript type definition of valid flags
* **program.ts**: wrap `serve` command in feature flag
* **utils.ts**: Add helper method to determine flag state where absence of a flag implies enabled
* **webpack.config.js**: Add configured flags to `process.env`

## Testing requirements
Make sure `bw serve` is fully disabled and has no impact on 

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
