### PR TITLE
Add deleted date to items

### DIFF
--- a/src/models/response/cipherResponse.ts
+++ b/src/models/response/cipherResponse.ts
@@ -13,6 +13,7 @@ export class CipherResponse extends CipherWithIds implements BaseResponse {
   object: string;
   attachments: AttachmentResponse[];
   revisionDate: Date;
+  deletedDate: Date;
   passwordHistory: PasswordHistoryResponse[];
 
   constructor(o: CipherView) {
@@ -23,6 +24,7 @@ export class CipherResponse extends CipherWithIds implements BaseResponse {
       this.attachments = o.attachments.map((a) => new AttachmentResponse(a));
     }
     this.revisionDate = o.revisionDate;
+    this.deletedDate = o.deletedDate;
     if (o.passwordHistory != null) {
       this.passwordHistory = o.passwordHistory.map((h) => new PasswordHistoryResponse(h));
     }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Asana task: https://app.asana.com/0/1169444489336079/1201764698049208/f

We currently do not indicate _trashed_ status for items returned from `bw get item`. This PR adds the `deletedDate` return. If null, the item is not trashed. If populated, it is populated with the DateTime the item was sent to the trash.

> Note: It is possible to determine if an item is deleted using the `bw list items` command rather than `bw get`, but this improved usability in this instance

## Code changes
* **cipherResponse**: Add a `deletedDate` property to the cipher item response.

## Testing requirements

test deleted date is properly populated and `null` for non-deleted items

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
