### PR TITLE
Fix error when using password generator not logged in

### DIFF
--- a/src/commands/serve.command.ts
+++ b/src/commands/serve.command.ts
@@ -84,7 +84,10 @@ export class ServeCommand {
       this.main.cryptoService,
       this.main.apiService
     );
-    this.generateCommand = new GenerateCommand(this.main.passwordGenerationService);
+    this.generateCommand = new GenerateCommand(
+      this.main.passwordGenerationService,
+      this.main.stateService
+    );
     this.syncCommand = new SyncCommand(this.main.syncService);
     this.statusCommand = new StatusCommand(
       this.main.environmentService,

--- a/src/program.ts
+++ b/src/program.ts
@@ -322,7 +322,10 @@ export class Program extends BaseProgram {
         writeLn("", true);
       })
       .action(async (options) => {
-        const command = new GenerateCommand(this.main.passwordGenerationService);
+        const command = new GenerateCommand(
+          this.main.passwordGenerationService,
+          this.main.stateService
+        );
         const response = await command.run(options);
         this.processResponse(response);
       });


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix #476.

The reviewer should confirm that still want to allow password generation when not logged in. However, this was the pre-v1.21.0 behaviour, so I've erred on the side of just fixing the regression and not changing behaviour.

TBC: whether this merits a hotfix.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

If the user is not logged in, don't try to retrieve the user's policies, just use the options provided.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
* confirm bug is fixed
* confirm Password Generator policy still works as expected if the user is logged in.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
