### PR TITLE
parse incoming JSON date strings as Date objects

### DIFF
--- a/src/commands/send/create.command.ts
+++ b/src/commands/send/create.command.ts
@@ -35,6 +35,8 @@ export class SendCreateCommand {
 
     if (typeof requestJson !== "string") {
       req = requestJson;
+      req.deletionDate = req.deletionDate == null ? null : new Date(req.deletionDate);
+      req.expirationDate = req.expirationDate == null ? null : new Date(req.expirationDate);
     } else {
       try {
         const reqJson = Buffer.from(requestJson, "base64").toString();

--- a/src/commands/send/edit.command.ts
+++ b/src/commands/send/edit.command.ts
@@ -28,6 +28,8 @@ export class SendEditCommand {
     let req: SendResponse = null;
     if (typeof requestJson !== "string") {
       req = requestJson;
+      req.deletionDate = req.deletionDate == null ? null : new Date(req.deletionDate);
+      req.expirationDate = req.expirationDate == null ? null : new Date(req.expirationDate);
     } else {
       try {
         const reqJson = Buffer.from(requestJson, "base64").toString();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

When parsing Send request object JSON, date fields will be received as strings. The SendResponse object expects them to be Date objects. This is manually handled when parsing the JSON in SendResponse.fromJson(), however, since Koa.js parses the JSON string into an object for us when using serve, we need to manually correct this.

Ideally, we need to move away from the SendResponse object for sends. It seems this object has been abused and is not appropriate for CLI request objects.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **send/edit.command.ts:** Parse date strings as Date objects.
- **send/create.command.ts:** Parse date strings as Date objects.

## Testing requirements

Repeat test procedures from https://app.asana.com/0/1153294014282570/1201747502562147

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
