### PR TITLE
added hostname option to serve command

### DIFF
--- a/src/commands/serve.command.ts
+++ b/src/commands/serve.command.ts
@@ -147,6 +147,7 @@ export class ServeCommand {
 
   async run(options: program.OptionValues) {
     const port = options.port || 8087;
+    const hostname = options.hostname || "localhost";
     const server = new koa();
     const router = new koaRouter();
     process.env.BW_SERVE = "true";
@@ -355,7 +356,7 @@ export class ServeCommand {
     server
       .use(router.routes())
       .use(router.allowedMethods())
-      .listen(port, () => {
+      .listen(port, hostname === "all" ? null : hostname, () => {
         this.main.logService.info("Listening on port " + port);
       });
   }

--- a/src/commands/serve.command.ts
+++ b/src/commands/serve.command.ts
@@ -357,7 +357,7 @@ export class ServeCommand {
       .use(router.routes())
       .use(router.allowedMethods())
       .listen(port, hostname === "all" ? null : hostname, () => {
-        this.main.logService.info("Listening on port " + port);
+        this.main.logService.info("Listening on " + hostname + ":" + port);
       });
   }
 

--- a/src/program.ts
+++ b/src/program.ts
@@ -470,12 +470,20 @@ export class Program extends BaseProgram {
       program
         .command("serve")
         .description("Start a RESTful API webserver.")
-        .option("--port <port>", "The port to run your API webserver on. Default port is 8087.")
+        .option("--hostname <hostname>", "The hostname to bind your API webserver to.")
+        .option("--port <port>", "The port to run your API webserver on.")
         .on("--help", () => {
-          writeLn("\n  Examples:");
+          writeLn("\n  Notes:");
+          writeLn("");
+          writeLn("    Default hostname is `localhost`.");
+          writeLn("    Use hostname `all` for no hostname binding.");
+          writeLn("    Default port is `8087`.");
+          writeLn("");
+          writeLn("  Examples:");
           writeLn("");
           writeLn("    bw serve");
           writeLn("    bw serve --port 8080");
+          writeLn("    bw serve --hostname bwapi.mydomain.com --port 80");
           writeLn("", true);
         })
         .action(async (cmd) => {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Provide a way to bind a hostname to the `serve` webserver. Also, provide a secure default.

Resolves https://github.com/bitwarden/cli/issues/518

## Code changes

- **serve.command.ts:** Add hostname binding to koa's `listen` function, which starts a webserver. Default to localhost.
- **program.ts:** Provide hostname option for `serve` and add docs to support it.

## Testing requirements

Launch `serve` command with and without hostname binding to ensure that it is not accessible from alternate hostnames (unless using `all` value).

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
